### PR TITLE
fixed injected pop up content issue

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,9 +1,9 @@
-import { saveAuditData } from "@/lib/storage";
 import {
+  closeScraperTab,
   closeScraperWindow,
   createScraperTab,
-  closeScraperTab,
 } from "@/lib/scraper-window";
+import { saveAuditData } from "@/lib/storage";
 
 export default defineBackground(() => {
   console.log("Hello background!", { id: browser.runtime.id });

--- a/entrypoints/degree-audit/index.html
+++ b/entrypoints/degree-audit/index.html
@@ -6,7 +6,7 @@
     <title>Degree Audit Plus</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="degree-audit-plus-page-root-container"></div>
     <script type="module" src="./main.tsx"></script>
   </body>
 </html>

--- a/entrypoints/degree-audit/main.tsx
+++ b/entrypoints/degree-audit/main.tsx
@@ -46,7 +46,9 @@ const MainContent = () => {
   );
 };
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const root = ReactDOM.createRoot(
+  document.getElementById("degree-audit-plus-page-root-container")!,
+);
 root.render(
   <React.StrictMode>
     <App />

--- a/entrypoints/popup-app/index.html
+++ b/entrypoints/popup-app/index.html
@@ -15,7 +15,7 @@
       background: white;
     "
   >
-    <div id="root"></div>
+    <div id="degree-audit-plus-popup-root-container"></div>
     <script type="module" src="./main.tsx"></script>
   </body>
 </html>

--- a/entrypoints/popup-app/main.tsx
+++ b/entrypoints/popup-app/main.tsx
@@ -1,26 +1,24 @@
-import React from "react";
+import type { DegreeAuditCardProps } from "@/lib/general-types";
+import { getAuditHistory } from "@/lib/storage";
+import { PlusIcon, SpinnerIcon } from "@phosphor-icons/react";
+import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
 import { browser } from "wxt/browser";
-import Button from "../components/common/button";
-import { DegreeAuditCardPopup } from "../components/audit-card";
-import "./style.css";
-import DAPLogo from "@/assets/svgs/dap-circle-logo";
 import logo from "../../public/logo.png";
-import { PlusIcon } from "@phosphor-icons/react";
-import { getAuditHistory } from "@/lib/storage";
-import type { DegreeAuditCardProps } from "@/lib/general-types";
-import { SpinnerIcon } from "@phosphor-icons/react";
+import { DegreeAuditCardPopup } from "../components/audit-card";
+import Button from "../components/common/button";
+import "./style.css";
 // import HypotheticalCourseModal, {
 //   type HypotheticalCourse,
 // } from "../components/hypothetical-course-modal";
 
 export default function App() {
-  const [audits, setAudits] = React.useState<DegreeAuditCardProps[]>([]);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState<string | null>(null);
-  const [showAll, setShowAll] = React.useState(false);
-  const [runningAudit, setRunningAudit] = React.useState(false);
-  const [isSyncing, setIsSyncing] = React.useState(false);
+  const [audits, setAudits] = useState<DegreeAuditCardProps[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showAll, setShowAll] = useState(false);
+  const [runningAudit, setRunningAudit] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
   // const [isAuthenticated, setIsAuthenticated] = React.useState(true);
   // const [isModalOpen, setIsModalOpen] = React.useState(false);
   // const [hypotheticalCourses, setHypotheticalCourses] = React.useState<
@@ -29,7 +27,8 @@ export default function App() {
   // Load audit history from cached storage
   // Storage is updated ONLY when user visits UT Direct audits home page
   // This allows popup to work from any page using cached data
-  React.useEffect(() => {
+
+  useEffect(() => {
     async function loadAudits() {
       try {
         console.log("Popup: Loading audit history from cached storage...");
@@ -60,7 +59,7 @@ export default function App() {
     loadAudits();
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // get sycn status for ui
     browser.runtime
       .sendMessage({ type: "GET_SYNC_STATUS" })
@@ -249,7 +248,7 @@ export default function App() {
           <span className="font-bold text-lg text-dap-primary leading-tight">
             Degree Audit
             <br />
-            Plus
+            Plus??
           </span>
         </div>
 
@@ -263,7 +262,7 @@ export default function App() {
             ) : (
               <div className="flex items-center space-x-2">
                 <PlusIcon size={24} />
-                <p className="text-lg font-bold">Run New Audit</p>
+                <p className="text-lg font-bold">Run New Audit!!!!</p>
               </div>
             )}
           </Button>
@@ -365,7 +364,9 @@ export default function App() {
 }
 
 // Only render if we're in the standalone popup context (not injected via content script)
-const rootElement = document.getElementById("root");
+const rootElement = document.getElementById(
+  "degree-audit-plus-popup-root-container",
+);
 if (rootElement) {
   ReactDOM.createRoot(rootElement).render(
     <React.StrictMode>


### PR DESCRIPTION
The problem where random URLs would have DAP content in them that broke the whole page is fixed!

The problem was the content was being injected at an ID of root, which theoretically was only in the injected pop-up, but in reality was a common component ID in regular pages and so was being added there as well. To fix it, all I did was change the ID tag from “root” to “degree-audit-plus-popup-root-container” which I think is sufficiently unlikely to be in a different page. Did the same (“root” -> “degree-audit-plus-page-root-container”) for the regular DAP page for safety but might be unnecessary.