### PR TITLE
DAP-60: audit-header

### DIFF
--- a/entrypoints/degree-audit/components/navbar.tsx
+++ b/entrypoints/degree-audit/components/navbar.tsx
@@ -104,13 +104,13 @@ const Navbar = () => {
           </span>
         </HStack>
         <IconButton
-          icon={<PencilIcon className="w-4 h-4" />}
+          icon={<PencilIcon className="w-5 h-5" />}
           label="Edit Audit"
           onClick={() => void toggleSidebar()}
           className="h-10 rounded-[5px] px-[18px] bg-[#bf5701] gap-1.5 text-sm font-bold"
         />
         <IconButton
-          icon={<ExportIcon className="w-4 h-4" />}
+          icon={<ExportIcon className="w-5 h-5" />}
           label="Share"
           className="h-10 rounded-[5px] px-[18px] bg-[#bf5701] gap-1.5 text-sm font-bold"
         />

--- a/entrypoints/degree-audit/main.tsx
+++ b/entrypoints/degree-audit/main.tsx
@@ -37,7 +37,7 @@ const MainContent = () => {
       fill
       x="center"
       className={clsx("w-full transition-[margin-left] duration-300 ease-out", {
-        "ml-[375px]": sidebarIsOpen,
+        "ml-[325px]": sidebarIsOpen,
         "ml-0": !sidebarIsOpen,
       })}
     >


### PR DESCRIPTION
Updated frontend design to match figma with proper buttons and slider
<img width="1248" height="124" alt="Screenshot 2026-03-26 at 2 00 11 PM" src="https://github.com/user-attachments/assets/35ca7f9f-b02c-4ee6-8896-a99186caa2ba" />

Compared to base figma design:
<img width="1532" height="218" alt="image (4)" src="https://github.com/user-attachments/assets/90747d6a-d714-4387-bfdf-023670b130e9" />
