### PR TITLE
core course recs are conetxt dependent now

### DIFF
--- a/entrypoints/components/course-add-modal.tsx
+++ b/entrypoints/components/course-add-modal.tsx
@@ -1,10 +1,6 @@
 import { searchCatalogCourses } from "@/lib/backend/db";
 import type {
   CatalogCourse,
-  Course,
-  CourseCode,
-  CourseId,
-  StringSemester,
 } from "@/lib/general-types";
 import {
   CaretLeftIcon,
@@ -14,7 +10,6 @@ import {
 } from "@phosphor-icons/react";
 import React, { useEffect, useState } from "react";
 import { cn } from "~/lib/utils";
-import { useAuditContext } from "../degree-audit/providers/audit-provider";
 import { useCourseModalContext } from "../degree-audit/providers/course-modal-provider";
 import Button from "./common/button";
 import SelectDropdown from "./common/select-dropdown";
@@ -82,30 +77,11 @@ interface CourseSearchContentProps {
   isLoading?: boolean;
 }
 
-function getCatalogCourseId(course: CatalogCourse): CourseId {
-  return `catalog-course-${course.uniqueId}`;
-}
-
-function syncCatalogCourseForCard(
-  courseMap: Record<CourseId, Course>,
-  course: CatalogCourse,
-): CourseId {
-  const courseId = getCatalogCourseId(course);
-
-  if (!courseMap[courseId]) {
-    courseMap[courseId] = {
-      id: courseId,
-      code: `${course.department} ${course.number}` as CourseCode,
-      name: course.fullName,
-      hours: course.creditHours,
-      semester:
-        `${course.semester.season} ${course.semester.year}` as StringSemester,
-      status: "Planned",
-      type: "In-Residence",
-    };
-  }
-
-  return courseId;
+function mapCatalogCourseToPreview(course: CatalogCourse) {
+  return {
+    code: `${course.department} ${course.number}`,
+    name: course.fullName,
+  };
 }
 
 export function CourseSearchContent({
@@ -113,7 +89,6 @@ export function CourseSearchContent({
   onSearchSubmit,
   isLoading = false,
 }: CourseSearchContentProps) {
-  const { courseMap } = useAuditContext();
   const { recommendedCourses: sharedRecommendedCourses } =
     useCourseModalContext();
   const displayedRecommendedCourses =
@@ -176,7 +151,7 @@ export function CourseSearchContent({
           {displayedRecommendedCourses.map((course) => (
             <CourseCard
               key={course.uniqueId}
-              courseId={syncCatalogCourseForCard(courseMap, course)}
+              previewCourse={mapCatalogCourseToPreview(course)}
               type="add"
             />
           ))}
@@ -326,7 +301,6 @@ export function CourseSuggestionContent({
   onSearchSubmit,
   isLoading = false,
 }: CourseSearchContentProps) {
-  const { courseMap } = useAuditContext();
   const { recommendedCourses: sharedRecommendedCourses } =
     useCourseModalContext();
   const displayedRecommendedCourses =
@@ -391,7 +365,7 @@ export function CourseSuggestionContent({
           {displayedRecommendedCourses.map((course) => (
             <CourseCard
               key={course.uniqueId}
-              courseId={syncCatalogCourseForCard(courseMap, course)}
+              previewCourse={mapCatalogCourseToPreview(course)}
               type="add"
             />
           ))}
@@ -536,8 +510,6 @@ export function CourseSearchResults({
   courses,
   onBack,
 }: CourseSearchResultsProps) {
-  const { courseMap } = useAuditContext();
-
   return (
     <div>
       <button
@@ -551,7 +523,7 @@ export function CourseSearchResults({
         {courses.map((course) => (
           <CourseCard
             key={course.uniqueId}
-            courseId={syncCatalogCourseForCard(courseMap, course)}
+            previewCourse={mapCatalogCourseToPreview(course)}
             className="w-full"
             type="add"
           />

--- a/entrypoints/components/course-add-modal.tsx
+++ b/entrypoints/components/course-add-modal.tsx
@@ -15,6 +15,7 @@ import {
 import React, { useEffect, useState } from "react";
 import { cn } from "~/lib/utils";
 import { useAuditContext } from "../degree-audit/providers/audit-provider";
+import { useCourseModalContext } from "../degree-audit/providers/course-modal-provider";
 import Button from "./common/button";
 import SelectDropdown from "./common/select-dropdown";
 import CourseCard from "./course-card";
@@ -108,11 +109,15 @@ function syncCatalogCourseForCard(
 }
 
 export function CourseSearchContent({
-  recommendedCourses = [],
+  recommendedCourses,
   onSearchSubmit,
   isLoading = false,
 }: CourseSearchContentProps) {
   const { courseMap } = useAuditContext();
+  const { recommendedCourses: sharedRecommendedCourses } =
+    useCourseModalContext();
+  const displayedRecommendedCourses =
+    recommendedCourses ?? sharedRecommendedCourses;
   const [formData, setFormData] = useState<CourseSearchData>({
     searchQuery: "",
     requirement: "",
@@ -168,7 +173,7 @@ export function CourseSearchContent({
       <div className="mb-6">
         <p className="font-semibold text-xl tracking-wide mb-3">Add Courses</p>
         <div className="space-y-2">
-          {recommendedCourses.map((course) => (
+          {displayedRecommendedCourses.map((course) => (
             <CourseCard
               key={course.uniqueId}
               courseId={syncCatalogCourseForCard(courseMap, course)}
@@ -317,11 +322,15 @@ export function CourseSearchContent({
 }
 
 export function CourseSuggestionContent({
-  recommendedCourses = [],
+  recommendedCourses,
   onSearchSubmit,
   isLoading = false,
 }: CourseSearchContentProps) {
   const { courseMap } = useAuditContext();
+  const { recommendedCourses: sharedRecommendedCourses } =
+    useCourseModalContext();
+  const displayedRecommendedCourses =
+    recommendedCourses ?? sharedRecommendedCourses;
   const [formData, setFormData] = useState<CourseSearchData>({
     searchQuery: "",
     requirement: "",
@@ -379,7 +388,7 @@ export function CourseSuggestionContent({
           Recommended
         </p>
         <div className="space-y-2">
-          {recommendedCourses.map((course) => (
+          {displayedRecommendedCourses.map((course) => (
             <CourseCard
               key={course.uniqueId}
               courseId={syncCatalogCourseForCard(courseMap, course)}

--- a/entrypoints/components/course-card.tsx
+++ b/entrypoints/components/course-card.tsx
@@ -1,4 +1,4 @@
-import { CourseId } from "@/lib/general-types";
+import { CourseCode, CourseId } from "@/lib/general-types";
 import { cn, getColorByCourseCode } from "@/lib/utils";
 import { useDraggable } from "@dnd-kit/core";
 import { DotsSixVerticalIcon } from "@phosphor-icons/react";
@@ -7,7 +7,11 @@ import { forwardRef } from "react";
 import { useAuditContext } from "../degree-audit/providers/audit-provider";
 
 export type CourseCardProps = {
-  courseId: CourseId;
+  courseId?: CourseId;
+  previewCourse?: {
+    code: string;
+    name: string;
+  };
   className?: string;
   showDots?: boolean;
   type?: "add";
@@ -17,9 +21,17 @@ const CourseCardVisual = forwardRef<
   HTMLDivElement,
   CourseCardProps & React.HTMLAttributes<HTMLDivElement>
 >((props, ref) => {
-  const { courseId, className, showDots = false, type, ...rest } = props;
-  const { name: fullName, code: courseName } =
-    useAuditContext().getCourseById(courseId);
+  const { courseId, previewCourse, className, showDots = false, type, ...rest } =
+    props;
+  const auditContext = useAuditContext();
+  const course = previewCourse ?? (courseId ? auditContext.getCourseById(courseId) : null);
+
+  if (!course) {
+    return null;
+  }
+
+  const fullName = course.name;
+  const courseName = course.code;
 
   return (
     <div
@@ -31,7 +43,7 @@ const CourseCardVisual = forwardRef<
       )}
     >
       <div
-        className={`w-6 flex items-center justify-center ${getColorByCourseCode(courseName).className} rounded-l-sm border-r-2 border-dap-border`}
+        className={`w-6 flex items-center justify-center ${getColorByCourseCode(courseName as CourseCode).className} rounded-l-sm border-r-2 border-dap-border`}
       >
         {showDots ? (
           <DotsSixVerticalIcon size={18} weight="bold" className="text-white" />
@@ -52,7 +64,13 @@ const CourseCardVisual = forwardRef<
 
 CourseCardVisual.displayName = "CourseCardVisual";
 
-const DraggableCourseCard = ({ courseId, className }: CourseCardProps) => {
+const DraggableCourseCard = ({
+  courseId,
+  className,
+}: {
+  courseId: CourseId;
+  className?: string;
+}) => {
   const { isDragging, attributes, listeners, setNodeRef } = useDraggable({
     id: courseId,
   });
@@ -75,6 +93,7 @@ const DraggableCourseCard = ({ courseId, className }: CourseCardProps) => {
 
 const CourseCard = ({
   courseId,
+  previewCourse,
   className,
   draggable,
   showDots = false,
@@ -82,14 +101,13 @@ const CourseCard = ({
 }: CourseCardProps & { draggable?: boolean }) => {
   return draggable ? (
     <DraggableCourseCard
-      courseId={courseId}
+      courseId={courseId!}
       className={className}
-      showDots={showDots}
-      type={type}
     />
   ) : (
     <CourseCardVisual
       courseId={courseId}
+      previewCourse={previewCourse}
       className={className}
       showDots={showDots}
       type={type}

--- a/entrypoints/degree-audit/components/degree-audit-page.tsx
+++ b/entrypoints/degree-audit/components/degree-audit-page.tsx
@@ -1,12 +1,9 @@
 import { HStack, VStack } from "@/entrypoints/components/common/helperdivs";
 import Title from "@/entrypoints/components/common/text";
 import "@/entrypoints/styles/content.css";
-import { searchCores } from "@/lib/backend/db";
-import { AuditRequirement, CatalogCourse, CoreArea } from "@/lib/general-types";
+import { AuditRequirement } from "@/lib/general-types";
 import { formatMajorLabel } from "@/lib/utils";
-import { useEffect } from "react";
 import { useAuditContext } from "../providers/audit-provider";
-import { useCourseModalContext } from "../providers/course-modal-provider";
 import { SimpleDegreeCompletionDonut } from "./degree-completion-donut";
 import { CreditHourTotalsCard, GPATotalsCard } from "./gpa-credit-cards";
 import RequirementBreakdown, { UnifiedDegreeCard } from "./requirement-breakdown";
@@ -27,96 +24,6 @@ function parseGpaSummary(text: string | undefined) {
     hoursUsed: Number(match[1]),
     points: Number(match[2]),
   };
-}
-
-// gets remaining core requreiemtsn needed with core area as key and hours needed as value
-const CORE_CODE_TO_NAME: Partial<Record<string, CoreArea>> = {
-  "090": "First-Year Signature Course",
-  "010": "Communication",
-  "040": "Humanities",
-  "070": "American and Texas Government",
-  "060": "U.S. History",
-  "080": "Social and Behavioral Sciences",
-  "020": "Mathematics",
-  "030": "Natural Science and Technology, Part I",
-  "093": "Natural Science and Technology, Part II",
-  "050": "Visual and Performing Arts",
-};
-
-// TODO function to get potential classes
-// need to make sure we handle compexities of the rules (like "2 of the following 3 classes") and also the fact that some classes can satisfy multiple requirements (like a class that satisfies both a core requirement and a major requirement)
-
-function getMissingCoreRequirements(
-  sections: AuditRequirement[],
-): Partial<Record<CoreArea, number>> {
-  const coreSection = sections.find(
-    (section) => section.title === "Core Curriculum",
-  );
-  if (!coreSection) {
-    return {};
-  }
-
-  return coreSection.rules.reduce<Partial<Record<CoreArea, number>>>(
-    (missing, rule) => {
-      const coreCode = rule.text.match(/CORE \((\d{3})\)/)?.[1];
-      const coreName = coreCode ? CORE_CODE_TO_NAME[coreCode] : undefined;
-
-      if (coreName && rule.remainingHours > 0) {
-        missing[coreName] = rule.remainingHours;
-      }
-
-      return missing;
-    },
-    {},
-  );
-}
-
-
-// gets a few core classes to suggest, tries to do one from each missing core first
-async function getSuggestedCoreCourses(
-  sections: AuditRequirement[],
-  maxSuggestions = 3,
-): Promise<CatalogCourse[]> {
-  const suggestionCount = Math.max(0, Math.floor(maxSuggestions));
-  const missingCoreEntries = Object.entries(getMissingCoreRequirements(sections))
-    .filter((entry): entry is [CoreArea, number] => entry[1] > 0)
-    .sort((a, b) => b[1] - a[1]);
-
-  if (suggestionCount === 0 || missingCoreEntries.length === 0) {
-    return [];
-  }
-
-  const courseBuckets = await Promise.all(
-    missingCoreEntries.map(([core]) => searchCores(suggestionCount, core)),
-  );
-
-  const suggestions: CatalogCourse[] = [];
-  const seenCourseIds = new Set<number>();
-
-  while (
-    suggestions.length < suggestionCount &&
-    courseBuckets.some((bucket) => bucket.length > 0)
-  ) {
-    for (const bucket of courseBuckets) {
-      while (bucket.length > 0 && seenCourseIds.has(bucket[0].uniqueId)) {
-        bucket.shift();
-      }
-
-      if (bucket.length === 0) {
-        continue;
-      }
-
-      const nextCourse = bucket.shift()!;
-      suggestions.push(nextCourse);
-      seenCourseIds.add(nextCourse.uniqueId);
-
-      if (suggestions.length === suggestionCount) {
-        break;
-      }
-    }
-  }
-
-  return suggestions;
 }
 
 const SidePanel = () => {
@@ -230,28 +137,6 @@ const MainContent = () => {
 };
 
 const DegreeAuditPage = () => {
-  const { sections } = useAuditContext();
-  const { setRecommendedCourses } = useCourseModalContext();
-
-  useEffect(() => {
-    async function logCoreSuggestions() {
-      const suggestedCourses = await getSuggestedCoreCourses(sections);
-      setRecommendedCourses(suggestedCourses);
-      console.log(
-        "[DegreeAuditPage] Missing core requirements:",
-        getMissingCoreRequirements(sections),
-      );
-      console.log(
-        "[DegreeAuditPage] Suggested core courses:",
-        suggestedCourses,
-      );
-    }
-
-    logCoreSuggestions().catch((error) => {
-      console.error("[DegreeAuditPage] Failed to load core suggestions:", error);
-    });
-  }, [sections, setRecommendedCourses]);
-
   return (
     <HStack fill x="between" className="w-full" gap={8}>
       <MainContent />

--- a/entrypoints/degree-audit/components/requirement-breakdown.tsx
+++ b/entrypoints/degree-audit/components/requirement-breakdown.tsx
@@ -182,7 +182,13 @@ const parseRequirementCode = (
 };
 
 // Individual requirement row with expandable courses
-const RequirementRow = ({ requirement }: { requirement: RequirementRule }) => {
+const RequirementRow = ({
+  requirement,
+  requirementTitle,
+}: {
+  requirement: RequirementRule;
+  requirementTitle: string;
+}) => {
   const { getCourseById } = useAuditContext();
   const { openModal } = useCourseModalContext();
 
@@ -235,7 +241,12 @@ const RequirementRow = ({ requirement }: { requirement: RequirementRule }) => {
             <Button
               fill="solid"
               className="bg-[var(--color-dap-orange)] hover:opacity-90 text-white border-none w-max px-[24px] h-[40px] rounded-md font-semibold text-base flex items-center justify-center gap-[16px]"
-              onClick={openModal}
+              onClick={() =>
+                openModal({
+                  requirementTitle,
+                  ruleTitle: requirement.text,
+                })
+              }
             >
               <PlusIcon className="w-5 h-5" weight="bold" />
               Add Planned Course
@@ -326,6 +337,7 @@ const RequirementBreakdown = (props: RequirementBreakdownProps) => {
               <RequirementRow
                 key={`${requirement.text.slice(0, 20)}-${idx}`}
                 requirement={requirement}
+                requirementTitle={title}
               />
             ))}
           </div>
@@ -399,6 +411,7 @@ export const UnifiedDegreeCard = ({ degreeTitle, sections }: UnifiedDegreeCardPr
                 <RequirementRow
                   key={`${requirement.text.slice(0, 20)}-${rIdx}`}
                   requirement={requirement}
+                  requirementTitle={section.title}
                 />
               ))}
             </div>

--- a/entrypoints/degree-audit/providers/course-modal-provider.tsx
+++ b/entrypoints/degree-audit/providers/course-modal-provider.tsx
@@ -1,15 +1,24 @@
-import type { CatalogCourse } from "@/lib/general-types";
-import { createContext, useContext, useState } from "react";
 import CourseAddModal from "@/entrypoints/components/course-add-modal";
+import {
+  getSuggestedCoreCourses,
+  getSuggestedCoursesForRequirement,
+} from "@/lib/backend/db";
+import type { CatalogCourse } from "@/lib/general-types";
+import { createContext, useContext, useEffect, useState } from "react";
+import { useAuditContext } from "./audit-provider";
 
 // Context for sharing audit data betw sidebar and main
+type RecommendationScope = {
+  requirementTitle?: string;
+  ruleTitle?: string;
+};
+
 interface CourseModalContextType {
   isOpen: boolean;
   recommendedCourses: CatalogCourse[];
   toggleModal: () => void;
-  openModal: () => void;
+  openModal: (scope?: RecommendationScope) => void;
   closeModal: () => void;
-  setRecommendedCourses: (courses: CatalogCourse[]) => void;
 }
 
 const CourseModalContext = createContext<CourseModalContextType | null>(null);
@@ -19,10 +28,49 @@ export const CourseModalContextProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { sections } = useAuditContext();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [recommendedCourses, setRecommendedCourses] = useState<CatalogCourse[]>(
     [],
   );
+  const [recommendationScope, setRecommendationScope] =
+    useState<RecommendationScope | null>(null);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    async function loadRecommendedCourses() {
+      const courses =
+        recommendationScope?.requirementTitle && recommendationScope?.ruleTitle
+          ? await getSuggestedCoursesForRequirement(
+              recommendationScope.requirementTitle,
+              recommendationScope.ruleTitle,
+            )
+          : await getSuggestedCoreCourses(sections);
+
+      if (!isCancelled) {
+        setRecommendedCourses(courses);
+      }
+    }
+
+    loadRecommendedCourses().catch((error) => {
+      console.error(
+        "[Course Modal Provider] Failed to load recommended courses:",
+        error,
+      );
+      if (!isCancelled) {
+        setRecommendedCourses([]);
+      }
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [
+    sections,
+    recommendationScope?.requirementTitle,
+    recommendationScope?.ruleTitle,
+  ]);
 
   return (
     <CourseModalContext.Provider
@@ -30,9 +78,14 @@ export const CourseModalContextProvider = ({
         isOpen,
         recommendedCourses,
         toggleModal: () => setIsOpen(!isOpen),
-        openModal: () => setIsOpen(true),
-        closeModal: () => setIsOpen(false),
-        setRecommendedCourses,
+        openModal: (scope) => {
+          setRecommendationScope(scope ?? null);
+          setIsOpen(true);
+        },
+        closeModal: () => {
+          setIsOpen(false);
+          setRecommendationScope(null);
+        },
       }}
     >
       {children}
@@ -40,7 +93,10 @@ export const CourseModalContextProvider = ({
       <CourseAddModal
         isOpen={isOpen}
         recommendedCourses={recommendedCourses}
-        onClose={() => setIsOpen(false)}
+        onClose={() => {
+          setIsOpen(false);
+          setRecommendationScope(null);
+        }}
         onSearch={(searchData) => {
           console.log("Search data:", searchData);
         }}

--- a/lib/backend/db.ts
+++ b/lib/backend/db.ts
@@ -1,5 +1,5 @@
 import Dexie from "dexie";
-import type { CatalogCourse, CoreArea } from "../general-types";
+import type { AuditRequirement, CatalogCourse, CoreArea } from "../general-types";
 import { DEPARTMENT_MAP } from "../examples/data/department-map";
 
 export class UTDatabase extends Dexie {
@@ -23,14 +23,138 @@ export function findCoursesByCore(core: CoreArea): Promise<CatalogCourse[]> {
 }
 
 // Returns up to n catalog courses that satisfy the given core requirement.
-export function searchCores(
+export async function searchCores(
   n: number,
   core: CoreArea,
 ): Promise<CatalogCourse[]> {
   const limit = Math.max(0, Math.floor(n));
-  return limit === 0
-    ? Promise.resolve([])
-    : db.courses.where("core").equals(core).limit(limit).toArray();
+  if (limit === 0) {
+    return [];
+  }
+
+  const courses = await findCoursesByCore(core);
+  const seenCourseCodes = new Set<string>();
+
+  return courses
+    .filter((course) => {
+      const courseCode = `${course.department} ${course.number}`;
+      if (seenCourseCodes.has(courseCode)) {
+        return false;
+      }
+
+      seenCourseCodes.add(courseCode);
+      return true;
+    })
+    .slice(0, limit);
+}
+
+const CORE_CODE_TO_NAME: Partial<Record<string, CoreArea>> = {
+  "090": "First-Year Signature Course",
+  "010": "Communication",
+  "040": "Humanities",
+  "070": "American and Texas Government",
+  "060": "U.S. History",
+  "080": "Social and Behavioral Sciences",
+  "020": "Mathematics",
+  "030": "Natural Science and Technology, Part I",
+  "093": "Natural Science and Technology, Part II",
+  "050": "Visual and Performing Arts",
+};
+
+export function getCoreAreaFromRequirementRule(
+  requirementTitle: string,
+  ruleText: string,
+): CoreArea | null {
+  if (requirementTitle !== "Core Curriculum") {
+    return null;
+  }
+
+  const coreCode = ruleText.match(/CORE \((\d{3})\)/)?.[1];
+  return coreCode ? (CORE_CODE_TO_NAME[coreCode] ?? null) : null;
+}
+
+export function getMissingCoreRequirements(
+  sections: AuditRequirement[],
+): Partial<Record<CoreArea, number>> {
+  const coreSection = sections.find(
+    (section) => section.title === "Core Curriculum",
+  );
+  if (!coreSection) {
+    return {};
+  }
+
+  return coreSection.rules.reduce<Partial<Record<CoreArea, number>>>(
+    (missing, rule) => {
+      const coreArea = getCoreAreaFromRequirementRule(coreSection.title, rule.text);
+
+      if (coreArea && rule.remainingHours > 0) {
+        missing[coreArea] = rule.remainingHours;
+      }
+
+      return missing;
+    },
+    {},
+  );
+}
+
+export async function getSuggestedCoreCourses(
+  sections: AuditRequirement[],
+  maxSuggestions = 3,
+): Promise<CatalogCourse[]> {
+  const suggestionCount = Math.max(0, Math.floor(maxSuggestions));
+  const missingCoreEntries = Object.entries(getMissingCoreRequirements(sections))
+    .filter((entry): entry is [CoreArea, number] => entry[1] > 0)
+    .sort((a, b) => b[1] - a[1]);
+
+  if (suggestionCount === 0 || missingCoreEntries.length === 0) {
+    return [];
+  }
+
+  const courseBuckets = await Promise.all(
+    missingCoreEntries.map(([core]) => searchCores(suggestionCount, core)),
+  );
+
+  const suggestions: CatalogCourse[] = [];
+  const seenCourseIds = new Set<number>();
+
+  while (
+    suggestions.length < suggestionCount &&
+    courseBuckets.some((bucket) => bucket.length > 0)
+  ) {
+    for (const bucket of courseBuckets) {
+      while (bucket.length > 0 && seenCourseIds.has(bucket[0].uniqueId)) {
+        bucket.shift();
+      }
+
+      if (bucket.length === 0) {
+        continue;
+      }
+
+      const nextCourse = bucket.shift()!;
+      suggestions.push(nextCourse);
+      seenCourseIds.add(nextCourse.uniqueId);
+
+      if (suggestions.length === suggestionCount) {
+        break;
+      }
+    }
+  }
+
+  return suggestions;
+}
+
+export function getSuggestedCoursesForRequirement(
+  requirementTitle: string,
+  ruleTitle: string,
+  maxSuggestions = 3,
+): Promise<CatalogCourse[]> {
+  const coreArea = getCoreAreaFromRequirementRule(requirementTitle, ruleTitle);
+
+  if (!coreArea) {
+    return Promise.resolve([]);
+  }
+
+  return searchCores(maxSuggestions, coreArea);
 }
 
 function getDepartmentCodesByName(departmentName: string): string[] {


### PR DESCRIPTION
##  summary of changes
- made add-course recommendations depend on the specific requirement rule that opened the flow
- limited core-scoped recommendations to catalog courses that satisfy that exact core requirement
- reused the existing provider-backed recommendation state so the shared add-course UI stays in sync


