### PR TITLE
Fixed search functionality on Planner View

### DIFF
--- a/entrypoints/components/course-add-modal.tsx
+++ b/entrypoints/components/course-add-modal.tsx
@@ -547,6 +547,23 @@ export function CourseSearchResults({
   );
 }
 
+export function CourseSearchPanel() {
+  const [view, setView] = useState(false);
+  const [courses, setCourses] = useState<CatalogCourse[]>([]);
+
+  return view ? (
+    <CourseSearchResults courses={courses} onBack={() => setView(false)} />
+  ) : (
+    <CourseSearchContent
+      onSearchSubmit={async (formData) => {
+        const results = await SearchCourses(formData);
+        setCourses(results);
+        setView(true);
+      }}
+    />
+  );
+}
+
 export default function CourseAddModal({
   isOpen,
   onClose,

--- a/entrypoints/degree-audit/planner-view/degree-planner-page.tsx
+++ b/entrypoints/degree-audit/planner-view/degree-planner-page.tsx
@@ -1,6 +1,6 @@
 import { HStack, VStack } from "@/entrypoints/components/common/helperdivs";
 import Title from "@/entrypoints/components/common/text";
-import { CourseSearchContent } from "@/entrypoints/components/course-add-modal";
+import { CourseSearchPanel } from "@/entrypoints/components/course-add-modal";
 import "@/entrypoints/styles/content.css";
 import { SimpleDegreeCompletionDonut } from "../components/degree-completion-donut";
 import SemesterDropdowns from "./semester-dropdowns";
@@ -14,7 +14,7 @@ const SidePanel = () => {
     >
       <SimpleDegreeCompletionDonut size={300} />
       <div className="w-sm mt-10 p-3 rounded-lg border border-gray-200 bg-[#FAFAF9]">
-        <CourseSearchContent />
+        <CourseSearchPanel />
       </div>
     </VStack>
   );


### PR DESCRIPTION
https://linear.app/longhorn-devs/issue/DAP-67/52-fix-planner-add-courses-search-panel-to-match-modal-search-flow

Planner View:
<img width="1710" height="886" alt="image" src="https://github.com/user-attachments/assets/d75f40e1-cd2a-4c67-b929-c582acb9506c" />
Audit Completion View:
<img width="1710" height="896" alt="image" src="https://github.com/user-attachments/assets/396db443-4701-4aed-bada-6fe1e9133850" />
