### PR TITLE
Feat: Added Composite Audits and relevant auxiliary functions.   

### DIFF
--- a/entrypoints/components/audit-card.tsx
+++ b/entrypoints/components/audit-card.tsx
@@ -19,14 +19,35 @@ const DegreeAuditCard: React.FC<DegreeAuditCardProps> = ({
   isExpanded = false,
   onToggle,
   onMenuClick,
+  onRename,
 }) => {
   const [menuOpen, setMenuOpen] = React.useState(false);
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [draftTitle, setDraftTitle] = React.useState(title);
 
   React.useEffect(() => {
     if (!isSelected) {
       setMenuOpen(false);
     }
   }, [isSelected]);
+
+  const saveRename = () => {
+    const nextTitle = draftTitle.trim();
+    setIsEditing(false);
+    setMenuOpen(false);
+
+    if (nextTitle && nextTitle !== title) {
+      onRename?.(nextTitle);
+    } else {
+      setDraftTitle(title);
+    }
+  };
+
+  const startRename = () => {
+    setDraftTitle(title);
+    setIsEditing(true);
+    setMenuOpen(false);
+  };
 
   return (
     <div
@@ -42,13 +63,38 @@ const DegreeAuditCard: React.FC<DegreeAuditCardProps> = ({
     >
       <div className="flex items-center justify-between">
         {/* Title */}
-        <div
-          className={`font-bold text-[18px] leading-tight ${
-            isSelected ? "text-white" : "text-dap-orange"
-          }`}
-        >
-          {title}
-        </div>
+        {isEditing ? (
+          <input
+            autoFocus
+            className="w-[160px] rounded border border-dap-border bg-background px-1 py-1 text-[18px] font-bold leading-tight text-text outline-none"
+            value={draftTitle}
+            onChange={(e) => setDraftTitle(e.target.value)}
+            onBlur={saveRename}
+            onClick={(e) => e.stopPropagation()}
+            onFocus={(e) => e.currentTarget.select()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.currentTarget.blur();
+              }
+              if (e.key === "Escape") {
+                setDraftTitle(title);
+                setIsEditing(false);
+              }
+            }}
+          />
+        ) : (
+          <div
+            className={`min-w-0 flex-1 truncate font-bold text-[18px] leading-tight ${
+              isSelected ? "text-white" : "text-dap-orange"
+            }`}
+            onDoubleClick={(e) => {
+              e.stopPropagation();
+              startRename();
+            }}
+          >
+            {title}
+          </div>
+        )}
 
         <div className="flex items-center gap-2">
           {/* Percentage Badge */}
@@ -86,7 +132,10 @@ const DegreeAuditCard: React.FC<DegreeAuditCardProps> = ({
           className="absolute right-0 top-full z-30 mt-2 min-w-[180px] rounded-[8px] border border-dap-border bg-background p-2 shadow-lg"
           onClick={(e) => e.stopPropagation()}
         >
-          <button className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[15px] hover:bg-hover-bg">
+          <button
+            className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[15px] hover:bg-hover-bg"
+            onClick={startRename}
+          >
             <PencilSimpleLine size={20} className="shrink-0" />
             <span>Rename</span>
           </button>

--- a/entrypoints/degree-audit/components/sidebar.tsx
+++ b/entrypoints/degree-audit/components/sidebar.tsx
@@ -17,7 +17,8 @@ import { useAuditContext } from "../providers/audit-provider";
 
 const Sidebar = () => {
   const { sidebarIsOpen, toggleSidebar } = usePreferences();
-  const { currentAuditId, setCurrentAuditId, history } = useAuditContext();
+  const { currentAuditId, setCurrentAuditId, history, renameAuditTitle } =
+    useAuditContext();
   // const [audits, setAudits] = useState<DegreeAuditCardProps[]>([]); //history
   // const [loading, setLoading] = useState(true);
 
@@ -95,6 +96,11 @@ const Sidebar = () => {
                   onToggle={() => {
                     if (audit.auditId) {
                       setCurrentAuditId(audit.auditId); // No page refresh, just update state
+                    }
+                  }}
+                  onRename={(title) => {
+                    if (audit.auditId) {
+                      renameAuditTitle(audit.auditId, title);
                     }
                   }}
                   onMenuClick={() => {

--- a/entrypoints/degree-audit/providers/audit-provider.tsx
+++ b/entrypoints/degree-audit/providers/audit-provider.tsx
@@ -1,19 +1,27 @@
 import { usePreferences } from "@/entrypoints/degree-audit/providers/preferences-provider";
-import { calculateWeightedDegreeCompletion } from "@/lib/audit-calculations";
+import {
+  calculateWeightedDegreeCompletion,
+  getDuplicateCourseRequirementFlags,
+  getCompositeAuditRequirements,
+} from "@/lib/audit-calculations";
 import {
   addPlannedCourse as addPlannedCourseToStorage,
   getAuditData,
   getAuditHistory,
   removePlannedCourse as removePlannedCourseFromStorage,
+  renameAudit,
   wipeAllPlannedCourses as wipeAllPlannedCoursesFromStorage,
 } from "@/lib/backend/storage";
 import {
   AuditHistoryData,
   AuditRequirement,
+  CompositeAuditData,
+  CompositeAuditRequirement,
   Course,
   CourseId,
   CurrentAuditProgress,
   DegreeAuditCardProps,
+  DuplicateCourseRequirementFlag,
   PlannedCourseOutline,
   RequirementRule,
   StringSemester,
@@ -35,10 +43,14 @@ type AuditRequirementLike = Omit<AuditRequirement, "rule"> & {
 interface AuditContextType {
   sections: AuditRequirement[];
   courses: Course[];
+  compositeAuditData: CompositeAuditData;
+  compositeRequirements: CompositeAuditRequirement[];
+  duplicateCourseFlags: DuplicateCourseRequirementFlag[];
   history: AuditHistoryData;
   currentAuditId: string;
   currentAudit: DegreeAuditCardProps;
   setCurrentAuditId: (id: string) => void;
+  renameAuditTitle: (auditId: string, title: string) => Promise<boolean>;
   progresses: CurrentAuditProgress;
   semesters: SemesterInfo;
   getCourseById: (id: CourseId) => Course;
@@ -98,6 +110,13 @@ function normalizeRequirements(
   }));
 }
 
+function getAuditDisplayName(
+  audit: DegreeAuditCardProps | undefined,
+  auditId: string,
+) {
+  return audit?.title ?? audit?.majors?.join("; ") ?? auditId;
+}
+
 export const AuditContextProvider = ({
   children,
 }: {
@@ -111,7 +130,18 @@ export const AuditContextProvider = ({
 
   const [courseDict, setCourseDict] = useState<Record<CourseId, Course>>({});
   const [sections, setSections] = useState<AuditRequirement[]>([]);
+  const [compositeAuditData, setCompositeAuditData] =
+    useState<CompositeAuditData>({ audits: [] });
   const [history, setHistory] = useState<AuditHistoryData>();
+
+  const compositeRequirements = useMemo(
+    () => getCompositeAuditRequirements(compositeAuditData),
+    [compositeAuditData],
+  );
+  const duplicateCourseFlags = useMemo(
+    () => getDuplicateCourseRequirementFlags(compositeAuditData),
+    [compositeAuditData],
+  );
 
   const progresses = useMemo(
     () => calculateWeightedDegreeCompletion(sections ?? [], courseDict),
@@ -230,6 +260,25 @@ export const AuditContextProvider = ({
     return numRemoved;
   }
 
+  // Keep the provider state in sync after storage accepts the rename.
+  async function renameAuditTitle(auditId: string, title: string) {
+    const cleanTitle = title.trim();
+    if (!cleanTitle) {
+      return false;
+    }
+
+    const updatedHistory = await renameAudit(auditId, cleanTitle);
+    if (!updatedHistory) {
+      return false;
+    }
+
+    setHistory(updatedHistory);
+    setCompositeAuditData((prev) => ({
+      audits: prev.audits.map((audit) => ({ ...audit, name: cleanTitle })),
+    }));
+    return true;
+  }
+
   const currentAudit = useMemo(() => {
     return history?.audits.find((a) => a.auditId === currentAuditId) ?? {};
   }, [history, currentAuditId]);
@@ -267,19 +316,21 @@ export const AuditContextProvider = ({
         // Load requirements from cache
         const cached = await getAuditData(currentAuditId!);
         if (cached) {
-          setSections(
-            cached.requirements.map((section) => ({
-              ...section,
-              rules: section.rules.map((rule) => ({
-                ...rule,
-                progressUnit: rule.progressUnit ?? "hours",
-                courses: rule.courses,
-              })),
-            })),
-          );
+          const namedAudit = {
+            ...cached,
+            name: getAuditDisplayName(matchingAudit, currentAuditId!),
+          };
+          const composite = { audits: [namedAudit] };
+          setCompositeAuditData(composite);
+          setSections(getCompositeAuditRequirements(composite));
           console.log("[Main] courses", cached.courses);
           setCourseDict(cached.courses);
-        } else console.warn(`[Main] Audit ${currentAuditId} not in cache.`);
+        } else {
+          setCompositeAuditData({ audits: [] });
+          setSections([]);
+          setCourseDict({});
+          console.warn(`[Main] Audit ${currentAuditId} not in cache.`);
+        }
 
         setLoaded(true);
       } catch (error) {
@@ -300,6 +351,9 @@ export const AuditContextProvider = ({
       value={{
         sections,
         courses: Object.values(courseDict),
+        compositeAuditData,
+        compositeRequirements,
+        duplicateCourseFlags,
         history: history!,
         semesters,
         currentAuditId,
@@ -309,6 +363,7 @@ export const AuditContextProvider = ({
           setCurrentAuditId(id);
           updateLastAuditId(id);
         },
+        renameAuditTitle,
         moveCourseToNewSemester,
         progresses,
         getCourseById: (id) => {

--- a/lib/audit-calculations.ts
+++ b/lib/audit-calculations.ts
@@ -1,9 +1,84 @@
 import type {
   AuditRequirement,
+  CompositeAuditData,
+  CompositeAuditRequirement,
   Course,
+  CourseCode,
   CourseId,
   CurrentAuditProgress,
+  DuplicateCourseRequirementFlag,
 } from "./general-types";
+
+// Give unnamed audits a readable fallback so the UI never shows a blank source.
+function getAuditName(
+  audit: CompositeAuditData["audits"][number],
+  index: number,
+) {
+  return audit.name ?? `Degree Audit ${index + 1}`;
+}
+
+// Find course codes that appear in requirements from more than one audit.
+export function getDuplicateCourseRequirementFlags(
+  composite: CompositeAuditData,
+): DuplicateCourseRequirementFlag[] {
+  const courseAudits = new Map<CourseCode, Set<string>>();
+
+  composite.audits.forEach((audit, auditIndex) => {
+    const auditName = getAuditName(audit, auditIndex);
+
+    audit.requirements.forEach((requirement) => {
+      requirement.rules.forEach((rule) => {
+        rule.courses.forEach((courseId) => {
+          const course = audit.courses[courseId];
+          if (!course) return;
+
+          const auditNames = courseAudits.get(course.code) ?? new Set<string>();
+          auditNames.add(auditName);
+          courseAudits.set(course.code, auditNames);
+        });
+      });
+    });
+  });
+
+  return Array.from(courseAudits.entries())
+    .filter(([, auditNames]) => auditNames.size > 1)
+    .map(([courseCode, auditNames]) => ({
+      courseCode,
+      auditNames: Array.from(auditNames),
+    }));
+}
+
+// Build the composite requirement list used by views that need all audits together.
+export function getCompositeAuditRequirements(
+  composite: CompositeAuditData,
+): CompositeAuditRequirement[] {
+  const duplicateCodes = new Set(
+    getDuplicateCourseRequirementFlags(composite).map(
+      (flag) => flag.courseCode,
+    ),
+  );
+
+  return composite.audits.flatMap((audit, auditIndex) => {
+    const auditName = getAuditName(audit, auditIndex);
+
+    return audit.requirements.map((requirement) => ({
+      ...requirement,
+      auditName,
+      duplicateCourseCodes: Array.from(
+        new Set(
+          requirement.rules.flatMap((rule) =>
+            rule.courses
+              .map((courseId) => audit.courses[courseId]?.code)
+              .filter(
+                (code): code is CourseCode =>
+                  !!code && duplicateCodes.has(code),
+              ),
+          ),
+        ),
+      ),
+    }));
+  });
+}
 
 export function calculateWeightedDegreeCompletion(
   sections: AuditRequirement[],

--- a/lib/backend/storage.ts
+++ b/lib/backend/storage.ts
@@ -31,6 +31,30 @@ export async function saveAuditHistory(
   }
 }
 
+// Rename only the history entry because that is what the sidebar displays.
+export async function renameAudit(
+  auditId: string,
+  title: string,
+): Promise<AuditHistoryData | null> {
+  try {
+    const history = await getAuditHistory();
+    if (!history) {
+      return null;
+    }
+
+    const audits = history.audits.map((audit) =>
+      audit.auditId === auditId ? { ...audit, title } : audit,
+    );
+    const updatedHistory = { ...history, audits, timestamp: Date.now() };
+
+    await browser.storage.local.set({ [STORAGE_KEY]: updatedHistory });
+    return updatedHistory;
+  } catch (e) {
+    console.error("Failed to rename audit:", e);
+    return null;
+  }
+}
+
 /**
  * Adds a course to the audit history.
  * @param auditId - The ID of the audit to add the course to.

--- a/lib/general-types.ts
+++ b/lib/general-types.ts
@@ -39,8 +39,15 @@ export type CurrentAuditProgress = {
  * courses which contains all the courses in the audit as a simple list.
  */
 export interface CachedAuditData {
+  // Display name used when this audit is shown inside a composite view.
+  name?: string;
   requirements: AuditRequirement[];
   courses: Record<CourseId, Course>;
+}
+
+// Holds multiple audits together so planner views can read all requirements at once.
+export interface CompositeAuditData {
+  audits: CachedAuditData[];
 }
 
 /**
@@ -90,6 +97,22 @@ export type RequirementRule = {
 export type AuditRequirement = {
   title: string;
   rules: RequirementRule[];
+};
+
+// Used by the audit provider after combining CompositeAuditData requirements for the existing UI.
+export type CompositeAuditRequirement = AuditRequirement & {
+  // Keeps each flattened requirement tied back to the audit it came from.
+  auditName: string;
+  // Lets planner/requirement UI flag repeated courses without deduping them.
+  duplicateCourseCodes: CourseCode[];
+};
+
+// Used by audit-calculations helpers to report courses shared across multiple audits.
+export type DuplicateCourseRequirementFlag = {
+  // Course code is used instead of course id because each audit has its own ids.
+  courseCode: CourseCode;
+  // The audit names where this course appears in requirements.
+  auditNames: string[];
 };
 
 export type CoreArea =
@@ -197,6 +220,7 @@ export interface DegreeAuditCardProps {
   isExpanded?: boolean;
   onToggle?: () => void;
   onMenuClick?: () => void;
+  onRename?: (title: string) => void;
 }
 
 export interface AuditHistoryData {

--- a/tests/validate-requirement-progress.ts
+++ b/tests/validate-requirement-progress.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
-import { calculateWeightedDegreeCompletion } from "../lib/audit-calculations";
+import {
+  calculateWeightedDegreeCompletion,
+  getDuplicateCourseRequirementFlags,
+  getCompositeAuditRequirements,
+} from "../lib/audit-calculations";
 import { parseRequirementProgress } from "../lib/backend/audit-scraper";
 import type {
   AuditRequirement,
+  CompositeAuditData,
   Course,
   RequirementRule,
 } from "../lib/general-types";
@@ -106,5 +111,48 @@ const cappedResults = calculateWeightedDegreeCompletion(
   courses,
 );
 assert.equal(cappedResults.sections[0].progress.planned, 2);
+
+const composite: CompositeAuditData = {
+  audits: [
+    {
+      name: "Computer Science BS",
+      requirements: sections,
+      courses,
+    },
+    {
+      name: "Mathematics Minor",
+      requirements: [
+        {
+          title: "Minor Requirements",
+          rules: [{ ...coursesRule, courses: ["minor-linear-algebra"] }],
+        },
+      ],
+      courses: {
+        "minor-linear-algebra": {
+          id: "minor-linear-algebra",
+          code: "M 341",
+          name: "Linear Algebra",
+          hours: 3,
+          semester: "Fall 2026",
+          status: "Completed",
+          type: "In-Residence",
+        },
+      },
+    },
+  ],
+};
+
+const compositeRequirements = getCompositeAuditRequirements(composite);
+const duplicateFlags = getDuplicateCourseRequirementFlags(composite);
+
+assert.equal(compositeRequirements.length, 2);
+assert.equal(duplicateFlags.length, 1);
+assert.equal(duplicateFlags[0].courseCode, "M 341");
+assert.deepEqual(duplicateFlags[0].auditNames, [
+  "Computer Science BS",
+  "Mathematics Minor",
+]);
+assert.deepEqual(compositeRequirements[0].duplicateCourseCodes, ["M 341"]);
+assert.deepEqual(compositeRequirements[1].duplicateCourseCodes, ["M 341"]);
 
 console.log("Requirement progress validation passed.");


### PR DESCRIPTION
## Changes I added :)

Resolved #160 

- Added composite audit data types in `lib/general-types.ts` so multiple cached audits can be represented together with audit display names.
- Added composite requirement helpers in `lib/audit-calculations.ts` to:
  - build a combined requirement list from composite audit data
  - flag course codes that appear across multiple audits without deduping them
- Updated `entrypoints/degree-audit/providers/audit-provider.tsx` to build composite audit data from the current audit while preserving existing single-audit UI paths.
- Added audit renaming support:
  - `renameAudit` storage helper in `lib/backend/storage.ts`
  - `renameAuditTitle` provider method in `audit-provider.tsx`
  - inline double-click rename UI in `entrypoints/components/audit-card.tsx`
  - sidebar wiring in `entrypoints/degree-audit/components/sidebar.tsx`
- Extended `tests/validate-requirement-progress.ts` to cover composite requirements and duplicate course flagging.


## Notes

- Existing single-audit code paths still work.
- Duplicate courses are flagged by course code, not deduplicated.
- The provider currently builds a one-audit composite; loading multiple audits can build on this model in the next issue.