### PR TITLE
Added auxillary methods to allow for CRUD of composite audits.

### DIFF
--- a/lib/backend/storage.ts
+++ b/lib/backend/storage.ts
@@ -367,7 +367,6 @@ export async function createComposite(
   return { saved, composite };
 }
 
-
 export async function updateCachedComposite(
   id: string,
   patch: Partial<Pick<CachedCompositeAudit, "name" | "auditIds">>,

--- a/lib/backend/storage.ts
+++ b/lib/backend/storage.ts
@@ -5,6 +5,8 @@ import { browser } from "wxt/browser";
 import type {
   AuditHistoryData,
   CachedAuditData,
+  CachedCompositeAudit,
+  CompositeAuditData,
   CourseId,
   DegreeAuditCardProps,
   PlannedCourseOutline,
@@ -284,4 +286,119 @@ export async function getUncachedAuditIds(
     if (!cached) uncached.push(id);
   }
   return uncached;
+}
+
+/**
+ * Helper function: Loads each saved audit from the per-audit cache and combines them into the
+ * composite model. IDs with no cached data (never scraped or failed to scrape)
+ * are skipped, so the remaining audits still load. Display names come from audit
+ * history, matching the provider's naming logic.
+ *
+ * @param auditIds - The IDs of the audits to load and combine.
+ * @returns A composite holding one entry per successfully loaded audit.
+ */
+export async function loadCompositeAuditData(
+  auditIds: string[],
+  options?: {
+    // Injectable for tests; defaults to the real storage readers.
+    getData?: (id: string) => Promise<CachedAuditData | null>;
+    getHistory?: () => Promise<AuditHistoryData | null>;
+  },
+): Promise<CompositeAuditData> {
+  const getData = options?.getData ?? getAuditData;
+  const getHistory = options?.getHistory ?? getAuditHistory;
+
+  const history = await getHistory();
+  const audits: CachedAuditData[] = [];
+
+  for (const id of auditIds) {
+    const data = await getData(id);
+    if (!data) continue; // not cached yet — skip so the others still load
+    const card = history?.audits.find((a) => a.auditId === id);
+    const name = card?.title ?? card?.majors?.join("; ") ?? id;
+    audits.push({ ...data, name });
+  }
+
+  return { audits };
+}
+
+// ---- Saved Composites (a named grouping of audits the user views together) ----
+const COMPOSITES_KEY = "compositeAudits";
+
+// Get all saved composites (returns an empty list if none).
+export async function getCachedComposites(): Promise<CachedCompositeAudit[]> {
+  try {
+    const result = await browser.storage.local.get(COMPOSITES_KEY);
+    return (result[COMPOSITES_KEY] as CachedCompositeAudit[]) ?? [];
+  } catch (e) {
+    console.error("Failed to get composites from storage:", e);
+    return [];
+  }
+}
+
+async function setCachedComposites(
+  composites: CachedCompositeAudit[],
+): Promise<void> {
+  await browser.storage.local.set({ [COMPOSITES_KEY]: composites });
+}
+
+/**
+ * Creates a new composite from a set of audits, frontend facing method  "create
+ * composite" audit. Persists only the name + member ids, then builds and
+ * returns the composite so the caller can render it immediately without a second
+ * round-trip.
+ *
+ * @param name - The user-facing label for the composite.
+ * @param auditIds - The IDs of the audits that make up the composite.
+ * @returns The stored record and the freshly built composite.
+ */
+export async function createComposite(
+  name: string,
+  auditIds: string[],
+): Promise<{ saved: CachedCompositeAudit; composite: CompositeAuditData }> {
+  const saved: CachedCompositeAudit = {
+    id: crypto.randomUUID(),
+    name,
+    auditIds,
+  };
+  const composites = await getCachedComposites();
+  await setCachedComposites([...composites, saved]);
+  const composite = await loadCompositeAuditData(auditIds);
+  return { saved, composite };
+}
+
+
+export async function updateCachedComposite(
+  id: string,
+  patch: Partial<Pick<CachedCompositeAudit, "name" | "auditIds">>,
+): Promise<CachedCompositeAudit | null> {
+  const composites = await getCachedComposites();
+  const existing = composites.find((c) => c.id === id);
+  if (!existing) return null;
+  const updated: CachedCompositeAudit = { ...existing, ...patch, id };
+  await setCachedComposites(composites.map((c) => (c.id === id ? updated : c)));
+  return updated;
+}
+
+export async function deleteCachedComposite(id: string): Promise<boolean> {
+  const composites = await getCachedComposites();
+  const next = composites.filter((c) => c.id !== id);
+  if (next.length === composites.length) return false;
+  await setCachedComposites(next);
+  return true;
+}
+
+/**
+ * Reopens a saved composite by rebuilding it from the per-audit cache.
+ *
+ * @param id - The ID of the composite to load.
+ * @returns The built composite, or null if no composite has that ID.
+ */
+export async function loadCompositeAudit(
+  id: string,
+): Promise<CompositeAuditData | null> {
+  const composites = await getCachedComposites();
+  const composite = composites.find((c) => c.id === id);
+  if (!composite) return null;
+  return loadCompositeAuditData(composite.auditIds);
 }

--- a/lib/general-types.ts
+++ b/lib/general-types.ts
@@ -50,6 +50,15 @@ export interface CompositeAuditData {
   audits: CachedAuditData[];
 }
 
+// A persisted composite. Stores only a name + the member audit ids; it does NOT cache audit
+// data. The full CompositeAuditData is rebuilt on demand from the per-audit cache
+// (auditData_<id>) so it never goes stale when planned courses change or audits re-scrape.
+export interface CachedCompositeAudit {
+  id: string; // crypto.randomUUID()
+  name: string; // user-facing label, e.g. "My Degree Plan"
+  auditIds: string[]; // ordered member ids -> point into auditData_<id>
+}
+
 /**
  * Simple way of expanding an object type one layer so it shows its children's contents
  */

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "compile": "bun run tsc --noEmit",
     "test:parse-major": "bun run tests/validate-parse-major.ts",
     "test:requirement-progress": "bun run tests/validate-requirement-progress.ts",
+    "test:composite-load": "bun run tests/validate-composite-audit-load.ts",
+    "test:saved-composites": "bun run tests/validate-saved-composites.ts",
     "postinstall": "bun run wxt prepare",
     "prepare": "husky",
     "tailwind:init": "bun run tailwindcss init -p"

--- a/tests/validate-composite-audit-load.ts
+++ b/tests/validate-composite-audit-load.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import {
+  getCompositeAuditRequirements,
+  getDuplicateCourseRequirementFlags,
+} from "../lib/audit-calculations";
+import { loadCompositeAuditData } from "../lib/backend/storage";
+import type { AuditHistoryData, CachedAuditData } from "../lib/general-types";
+
+// --- Fixtures ---------------------------------------------------------------
+
+// Two audits that share a course code (M 341) so the composite helpers have a
+// duplicate to flag once the audits are combined.
+const csAudit: CachedAuditData = {
+  requirements: [
+    {
+      title: "Major Requirements",
+      rules: [
+        {
+          text: "Linear Algebra",
+          requiredHours: 3,
+          appliedHours: 3,
+          remainingHours: 0,
+          progressUnit: "hours",
+          status: "Completed",
+          courses: ["cs-linear-algebra"],
+        },
+      ],
+    },
+  ],
+  courses: {
+    "cs-linear-algebra": {
+      id: "cs-linear-algebra",
+      code: "M 341",
+      name: "Linear Algebra",
+      hours: 3,
+      semester: "Fall 2026",
+      status: "Completed",
+      type: "In-Residence",
+    },
+  },
+};
+
+const mathMinorAudit: CachedAuditData = {
+  requirements: [
+    {
+      title: "Minor Requirements",
+      rules: [
+        {
+          text: "Linear Algebra",
+          requiredHours: 3,
+          appliedHours: 3,
+          remainingHours: 0,
+          progressUnit: "hours",
+          status: "Completed",
+          courses: ["minor-linear-algebra"],
+        },
+      ],
+    },
+  ],
+  courses: {
+    "minor-linear-algebra": {
+      id: "minor-linear-algebra",
+      code: "M 341",
+      name: "Linear Algebra",
+      hours: 3,
+      semester: "Fall 2026",
+      status: "Completed",
+      type: "In-Residence",
+    },
+  },
+};
+
+const cache: Record<string, CachedAuditData> = {
+  "audit-cs": csAudit,
+  "audit-math-minor": mathMinorAudit,
+};
+
+const history: AuditHistoryData = {
+  audits: [
+    {
+      auditId: "audit-cs",
+      title: "Computer Science BS",
+      majors: ["Computer Science"],
+    },
+    {
+      auditId: "audit-math-minor",
+      majors: ["Mathematics"],
+      minors: ["Mathematics"],
+    },
+  ],
+  timestamp: 0,
+};
+
+const mockGetData = (id: string) => Promise.resolve(cache[id] ?? null);
+const mockGetHistory = () => Promise.resolve(history);
+
+// --- Tests ------------------------------------------------------------------
+
+// Combines multiple saved audits into the composite (AC #2).
+{
+  const composite = await loadCompositeAuditData(
+    ["audit-cs", "audit-math-minor"],
+    { getData: mockGetData, getHistory: mockGetHistory },
+  );
+
+  assert.equal(composite.audits.length, 2);
+  // Name resolves from history title, then majors, then the raw id.
+  assert.equal(composite.audits[0].name, "Computer Science BS");
+  assert.equal(composite.audits[1].name, "Mathematics");
+}
+
+// Falls back to the raw id when history has no entry for the audit.
+{
+  const composite = await loadCompositeAuditData(["audit-cs"], {
+    getData: mockGetData,
+    getHistory: () => Promise.resolve(null),
+  });
+
+  assert.equal(composite.audits.length, 1);
+  assert.equal(composite.audits[0].name, "audit-cs");
+}
+
+// Skips uncached IDs so the remaining audits still load (AC #3, #4).
+{
+  const composite = await loadCompositeAuditData(
+    ["audit-cs", "missing-audit", "audit-math-minor"],
+    { getData: mockGetData, getHistory: mockGetHistory },
+  );
+
+  assert.equal(composite.audits.length, 2);
+  assert.deepEqual(
+    composite.audits.map((a) => a.name),
+    ["Computer Science BS", "Mathematics"],
+  );
+}
+
+// The combined composite is consumed correctly by the 6.1 helpers.
+{
+  const composite = await loadCompositeAuditData(
+    ["audit-cs", "audit-math-minor"],
+    { getData: mockGetData, getHistory: mockGetHistory },
+  );
+
+  const compositeRequirements = getCompositeAuditRequirements(composite);
+  const duplicateFlags = getDuplicateCourseRequirementFlags(composite);
+
+  assert.equal(compositeRequirements.length, 2);
+  assert.deepEqual(compositeRequirements[0].duplicateCourseCodes, ["M 341"]);
+  assert.deepEqual(compositeRequirements[1].duplicateCourseCodes, ["M 341"]);
+
+  assert.equal(duplicateFlags.length, 1);
+  assert.equal(duplicateFlags[0].courseCode, "M 341");
+  assert.deepEqual(duplicateFlags[0].auditNames, [
+    "Computer Science BS",
+    "Mathematics",
+  ]);
+}
+
+console.log("Composite audit load validation passed.");

--- a/tests/validate-saved-composites.ts
+++ b/tests/validate-saved-composites.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import {
+  getCompositeAuditRequirements,
+  getDuplicateCourseRequirementFlags,
+} from "../lib/audit-calculations";
+import type { AuditHistoryData, CachedAuditData } from "../lib/general-types";
+
+// --- In-memory storage stub -------------------------------------------------
+// `wxt/browser` resolves to globalThis.chrome at import time, which is undefined
+// under Bun. Install a tiny in-memory chrome.storage.local before importing the
+// storage module so the real CRUD functions can run end-to-end.
+const store: Record<string, unknown> = {};
+(globalThis as unknown as { chrome: unknown }).chrome = {
+  storage: {
+    local: {
+      get: async (key: string) => ({ [key]: store[key] }),
+      set: async (obj: Record<string, unknown>) => {
+        Object.assign(store, obj);
+      },
+      remove: async (key: string) => {
+        delete store[key];
+      },
+    },
+  },
+};
+
+const {
+  createComposite,
+  getCachedComposites,
+  updateCachedComposite,
+  deleteCachedComposite,
+  loadCompositeAudit,
+} = await import("../lib/backend/storage");
+
+// --- Fixtures ---------------------------------------------------------------
+// Two audits that share course code M 341 so the composite helpers have a
+// duplicate to flag once the audits are combined.
+function auditWith(ruleCourseId: string): CachedAuditData {
+  return {
+    requirements: [
+      {
+        title: "Requirements",
+        rules: [
+          {
+            text: "Linear Algebra",
+            requiredHours: 3,
+            appliedHours: 3,
+            remainingHours: 0,
+            progressUnit: "hours",
+            status: "Completed",
+            courses: [ruleCourseId],
+          },
+        ],
+      },
+    ],
+    courses: {
+      [ruleCourseId]: {
+        id: ruleCourseId,
+        code: "M 341",
+        name: "Linear Algebra",
+        hours: 3,
+        semester: "Fall 2026",
+        status: "Completed",
+        type: "In-Residence",
+      },
+    },
+  };
+}
+
+const history: AuditHistoryData = {
+  audits: [
+    {
+      auditId: "audit-cs",
+      title: "Computer Science BS",
+      majors: ["Computer Science"],
+    },
+    { auditId: "audit-math-minor", majors: ["Mathematics"] },
+  ],
+  timestamp: 0,
+};
+
+// Seed the per-audit cache + history the way the scraper/history flow would.
+store["auditData_audit-cs"] = auditWith("cs-linear-algebra");
+store["auditData_audit-math-minor"] = auditWith("minor-linear-algebra");
+store["auditHistory"] = history;
+
+// --- Tests ------------------------------------------------------------------
+
+// create — stores the record and returns a freshly built composite.
+const { saved, composite } = await createComposite("My Plan", [
+  "audit-cs",
+  "audit-math-minor",
+]);
+
+assert.ok(saved.id, "created composite has an id");
+assert.equal(saved.name, "My Plan");
+assert.deepEqual(saved.auditIds, ["audit-cs", "audit-math-minor"]);
+assert.equal(composite.audits.length, 2);
+assert.deepEqual(
+  composite.audits.map((a) => a.name),
+  ["Computer Science BS", "Mathematics"],
+);
+
+{
+  const list = await getCachedComposites();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].id, saved.id);
+}
+
+// create a second — list grows, ids are distinct.
+const second = await createComposite("CS only", ["audit-cs"]);
+{
+  const list = await getCachedComposites();
+  assert.equal(list.length, 2);
+  assert.notEqual(saved.id, second.saved.id);
+}
+
+// update — renames in place and keeps the id; missing id returns null.
+{
+  const updated = await updateCachedComposite(saved.id, { name: "Renamed" });
+  assert.equal(updated?.name, "Renamed");
+  assert.equal(updated?.id, saved.id);
+
+  const list = await getCachedComposites();
+  assert.equal(list.find((c) => c.id === saved.id)?.name, "Renamed");
+
+  assert.equal(await updateCachedComposite("missing", { name: "x" }), null);
+}
+
+// reopen (build-on-demand) — rebuilds from the cache; missing member is skipped.
+{
+  await updateCachedComposite(saved.id, {
+    auditIds: ["audit-cs", "missing-audit", "audit-math-minor"],
+  });
+
+  const built = await loadCompositeAudit(saved.id);
+  assert.ok(built);
+  assert.equal(built!.audits.length, 2); // missing-audit dropped, others load
+
+  // The rebuilt composite is valid for the existing 6.1 helpers.
+  const compositeRequirements = getCompositeAuditRequirements(built!);
+  const duplicateFlags = getDuplicateCourseRequirementFlags(built!);
+  assert.equal(compositeRequirements.length, 2);
+  assert.deepEqual(compositeRequirements[0].duplicateCourseCodes, ["M 341"]);
+  assert.equal(duplicateFlags.length, 1);
+  assert.equal(duplicateFlags[0].courseCode, "M 341");
+
+  assert.equal(await loadCompositeAudit("missing"), null);
+}
+
+// delete — removes the record; missing id returns false.
+{
+  assert.equal(await deleteCachedComposite(saved.id), true);
+  const list = await getCachedComposites();
+  assert.equal(list.length, 1);
+  assert.equal(
+    list.find((c) => c.id === saved.id),
+    undefined,
+  );
+
+  assert.equal(await deleteCachedComposite("missing"), false);
+}
+
+console.log("Saved composites validation passed.");


### PR DESCRIPTION
Solves #156 

Composites are stored NOT as full objects with data — we save only { id, name, auditIds }, not the audit data itself. The per-audit cache (auditData_<id>) stays
  the single source of truth, so a composite is just a view over existing audits. We use the audits already scraped/cached, load each by id, and
  rebuild the full composite on demand — so it never goes stale when planned courses change or audits re-scrape.
  
  createComposite / loadCompositeAudit → loadCompositeAuditData(auditIds) (loads each cached audit, combines them) → the existing 6.1 helpers
  (getCompositeAuditRequirements / getDuplicateCourseRequirementFlags) flag shared courses.

  Methods added (lib/backend/storage.ts)

  - Create — createComposite(name, auditIds): stores the new composite and returns { saved, composite } (record + freshly built composite) in one
  call.
  - Read — getCachedComposites(): lists all saved composites. loadCompositeAudit(id): rebuilds and returns a composite by id.
  - Update — updateCachedComposite(id, patch): rename or change members; null if not found.
  - Delete — deleteCachedComposite(id): removes the composite (member audits untouched); false if not found.

  New type CachedCompositeAudit { id, name, auditIds }. Uncached/deleted member audits are skipped on load rather than crashing.