### PR TITLE
Implemented validation states types for plan requirements

### DIFF
--- a/entrypoints/degree-audit/components/course-add-panel.tsx
+++ b/entrypoints/degree-audit/components/course-add-panel.tsx
@@ -1,0 +1,157 @@
+import { CourseSearchContent } from "@/entrypoints/components/course-add-modal";
+import { searchCatalogCourses } from "@/lib/backend/db";
+import type {
+  CatalogCourse,
+  CourseRequirementFit,
+  PlanRequirementValidationState,
+} from "@/lib/general-types";
+import {
+  isCourseRequirementFulfilled,
+  isValidationChecking,
+} from "@/lib/general-types";
+import {
+  CaretLeftIcon,
+  DotsSixVerticalIcon,
+  PlusCircleIcon,
+  PlusIcon,
+} from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+
+// Placeholder for the future fulfillment check when the course is added.
+const try_add_course = async (
+  _course: CatalogCourse,
+): Promise<CourseRequirementFit> => ({
+  kind: "no-match",
+  message: "Requirement check not yet implemented.",
+});
+
+export default function CourseAddPanel() {
+  const [results, setResults] = useState<CatalogCourse[] | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [validationState, setValidationState] =
+    useState<PlanRequirementValidationState>({ status: "idle" });
+  const fulfillmentRequestId = useRef(0);
+
+  // Mark the course as selected, then ask whether it satisfies a requirement.
+  const selectCourse = async (course: CatalogCourse) => {
+    const requestId = ++fulfillmentRequestId.current;
+    setSelectedId(course.uniqueId);
+    setValidationState({ status: "checking" });
+
+    const result = await try_add_course(course);
+    if (fulfillmentRequestId.current !== requestId) return;
+
+    setValidationState({ status: "resolved", result });
+  };
+
+  const resetState = () => {
+    fulfillmentRequestId.current += 1;
+    setResults(null);
+    setSelectedId(null);
+    setValidationState({ status: "idle" });
+  };
+
+  if (results === null) {
+    return (
+      <CourseSearchContent
+        // Search submits populate the list and reset any prior selection state.
+        onSearchSubmit={async (formData) => {
+          const found = await searchCatalogCourses(formData);
+          setResults(found);
+          setSelectedId(null);
+          setValidationState({ status: "idle" });
+        }}
+      />
+    );
+  }
+
+  const selectedCourse = results.find(
+    (course) => course.uniqueId === selectedId,
+  );
+  const canAddCourse =
+    validationState.status === "resolved" &&
+    isCourseRequirementFulfilled(validationState.result);
+
+  const fulfillmentText = isValidationChecking(validationState)
+    ? "Checking requirement fit..."
+    : validationState.status === "resolved"
+      ? validationState.result.kind === "fulfills"
+        ? validationState.result.message
+        : validationState.result.kind === "no-match"
+          ? validationState.result.message
+          : validationState.result.reason
+      : null;
+
+  return (
+    <div className="flex flex-col">
+      <p className="font-bold text-2xl mb-4">Add courses</p>
+      <button
+        type="button"
+        onClick={resetState}
+        className="flex items-center gap-1 text-dap-orange font-semibold text-[13px] uppercase tracking-wide mb-4 hover:underline"
+      >
+        <CaretLeftIcon size={16} weight="bold" />
+        Search Results
+      </button>
+
+      <div className="space-y-3 max-h-[420px] overflow-y-auto pr-1">
+        {results.map((course) => {
+          const code = `${course.department} ${course.number}`;
+          const isSelected = course.uniqueId === selectedId;
+
+          return (
+            <button
+              key={course.uniqueId}
+              type="button"
+              onClick={() => void selectCourse(course)}
+              className={`w-full min-h-[70px] grid grid-cols-[22px_1fr_44px] items-stretch overflow-hidden rounded-md border bg-white text-left transition-colors ${
+                isSelected
+                  ? "border-2 border-[#579D42]"
+                  : "border-[#E5E1DA] hover:border-gray-300"
+              }`}
+            >
+              <div className="bg-dap-orange flex items-center justify-center">
+                <DotsSixVerticalIcon
+                  size={16}
+                  weight="bold"
+                  className="text-white"
+                />
+              </div>
+              <div className="px-3 py-3">
+                <p className="text-base font-semibold text-gray-900 leading-tight">
+                  {code}
+                </p>
+                <p className="mt-1 text-sm font-medium text-black leading-tight uppercase">
+                  {course.fullName}
+                </p>
+              </div>
+              <div className="flex items-center justify-center">
+                <PlusCircleIcon size={24} className="text-gray-700" />
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-7 min-h-[62px]">
+        {fulfillmentText !== null ? (
+          <div className="rounded-md border border-[#63B031] bg-[#F4FFE6] px-5 py-5 text-sm text-black">
+            {fulfillmentText}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-8 flex justify-end">
+        <button
+          type="button"
+          onClick={() => selectedCourse && void selectCourse(selectedCourse)}
+          disabled={!canAddCourse}
+          className="flex h-14 items-center justify-center gap-2 rounded-md bg-[#579D42] px-7 text-xl font-bold text-white transition-colors hover:bg-[#4C8F3B] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <PlusIcon size={28} weight="light" />
+          Add Course
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/general-types.ts
+++ b/lib/general-types.ts
@@ -99,6 +99,7 @@ export type AuditRequirement = {
   rules: RequirementRule[];
 };
 
+<<<<<<< Updated upstream
 // Used by the audit provider after combining CompositeAuditData requirements for the existing UI.
 export type CompositeAuditRequirement = AuditRequirement & {
   // Keeps each flattened requirement tied back to the audit it came from.
@@ -114,6 +115,144 @@ export type DuplicateCourseRequirementFlag = {
   // The audit names where this course appears in requirements.
   auditNames: string[];
 };
+=======
+/**
+ * The outcome of checking whether a CatalogCourse satisfies a plan requirement rule.
+ * - "fulfills"     – course satisfies an identified rule; carries requirementTitle + ruleTitle
+ *                    needed by addPlannedCourse(), plus a display message.
+ * - "no-match"     – course was checked but does not fulfill any outstanding rule.
+ * - "check-failed" – check could not complete (missing data, error); carries a reason string.
+ */
+export type CourseRequirementFit =
+  | {
+      kind: "fulfills";
+      requirementTitle: string;
+      ruleTitle: string;
+      message: string;
+    }
+  | { kind: "no-match"; message: string }
+  | { kind: "check-failed"; reason: string };
+
+/**
+ * The current state of the requirement-fit check in the course-add panel.
+ * - "idle"     – no course selected; nothing to show.
+ * - "checking" – async check is in flight.
+ * - "resolved" – check complete; result carries the CourseRequirementFit outcome.
+ */
+export type PlanRequirementValidationState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "resolved"; result: CourseRequirementFit };
+
+export function isValidationChecking(
+  state: PlanRequirementValidationState,
+): boolean {
+  return state.status === "checking";
+}
+
+export function isCourseRequirementFulfilled(
+  fit: CourseRequirementFit,
+): fit is Extract<CourseRequirementFit, { kind: "fulfills" }> {
+  return fit.kind === "fulfills";
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Plan requirement validation state (DAP-84 / 6.4)
+ *
+ * Every requirement in a degree plan carries two INDEPENDENT dimensions:
+ *   1. its validation result – what the last check found.
+ *   2. its staleness         – whether the plan changed since that check.
+ * They are tracked separately (not one enum) so "was confirmed, now stale" stays
+ * distinguishable from "was failed, now stale".
+ *
+ * Distinct from PlanRequirementValidationState above, which is the course-add
+ * panel's transient async UI state (idle / checking / resolved).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Identifies an audit. Audits are keyed by id in storage (`auditData_<id>`). */
+export type AuditId = string;
+
+/**
+ * Identifies a requirement within an audit. Requirements have no separate id, so
+ * they are identified by their title (matches `AuditRequirement.title`), assumed
+ * unique within a single audit — consistent with how `addPlannedCourse` resolves
+ * a requirement by title.
+ */
+export type RequirementId = string;
+
+/**
+ * What the last validation found for a requirement.
+ * - "unchecked" – default; no validation has run on this requirement yet.
+ * - "confirmed" – last validation found it satisfied by the current plan.
+ * - "failed"    – last validation found it NOT satisfied.
+ */
+export type ValidationResult = "unchecked" | "confirmed" | "failed";
+
+/**
+ * The full per-requirement validation state — both dimensions in one record:
+ * - result        – the last validation outcome.
+ * - isStale       – true if the plan changed since `lastValidated`, so `result`
+ *                   may be outdated. A SEPARATE flag, never folded into `result`.
+ * - lastValidated – when `result` was produced, or null if never validated.
+ */
+export interface RequirementValidation {
+  result: ValidationResult;
+  isStale: boolean;
+  lastValidated: Date | null;
+}
+
+/** The default state for a requirement that has never been validated. */
+export function unvalidatedRequirement(): RequirementValidation {
+  return { result: "unchecked", isStale: false, lastValidated: null };
+}
+
+/**
+ * Validation state for one audit: a RequirementValidation per requirement, keyed
+ * by requirement title.
+ */
+export type AuditValidationState = Record<RequirementId, RequirementValidation>;
+
+/**
+ * Validation state for a whole composite plan: per-audit, then per-requirement.
+ * Mirrors 6.1's composite shape — CompositeAuditData holds one CachedAuditData
+ * per member audit id, each with its own requirements — so this map slots onto
+ * the composite with one AuditValidationState per audit id.
+ */
+export type CompositeValidationState = Record<AuditId, AuditValidationState>;
+
+/**
+ * A change to the plan that may invalidate prior validation results — a planned
+ * course added to, removed from, or moved within a requirement. Each change names
+ * the audit it happened in, so the requirements it makes stale address the
+ * matching per-audit slot of CompositeValidationState. (move-course carries no
+ * requirementTitle: a semester move marks nothing stale, so it needs none.)
+ */
+export type PlanChange =
+  | { kind: "add-course"; auditId: AuditId; requirementTitle: RequirementId }
+  | { kind: "remove-course"; auditId: AuditId; requirementTitle: RequirementId }
+  | { kind: "move-course"; auditId: AuditId };
+
+/**
+ * Given a plan change, returns the requirement IDs (titles) within
+ * `change.auditId` whose validation result should be marked stale — i.e. the
+ * requirements to invalidate inside `CompositeValidationState[change.auditId]`.
+ *
+ * Intentionally conservative for v1 (see the ticket's staleness note): adding or
+ * removing a planned course only invalidates the one requirement it applies to,
+ * and moving a course between semesters does not change whether a requirement is
+ * satisfied, so it marks nothing stale. Combination-sensitive cross-requirement
+ * staleness is a future refinement, not a v1 blocker.
+ */
+export function requirementsMadeStaleBy(change: PlanChange): RequirementId[] {
+  switch (change.kind) {
+    case "add-course":
+    case "remove-course":
+      return [change.requirementTitle];
+    case "move-course":
+      return [];
+  }
+}
+>>>>>>> Stashed changes
 
 export type CoreArea =
   | "First-Year Signature Course"

--- a/lib/general-types.ts
+++ b/lib/general-types.ts
@@ -99,7 +99,6 @@ export type AuditRequirement = {
   rules: RequirementRule[];
 };
 
-<<<<<<< Updated upstream
 // Used by the audit provider after combining CompositeAuditData requirements for the existing UI.
 export type CompositeAuditRequirement = AuditRequirement & {
   // Keeps each flattened requirement tied back to the audit it came from.
@@ -115,7 +114,7 @@ export type DuplicateCourseRequirementFlag = {
   // The audit names where this course appears in requirements.
   auditNames: string[];
 };
-=======
+
 /**
  * The outcome of checking whether a CatalogCourse satisfies a plan requirement rule.
  * - "fulfills"     – course satisfies an identified rule; carries requirementTitle + ruleTitle
@@ -252,7 +251,6 @@ export function requirementsMadeStaleBy(change: PlanChange): RequirementId[] {
       return [];
   }
 }
->>>>>>> Stashed changes
 
 export type CoreArea =
   | "First-Year Signature Course"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "compile": "bun run tsc --noEmit",
     "test:parse-major": "bun run tests/validate-parse-major.ts",
     "test:requirement-progress": "bun run tests/validate-requirement-progress.ts",
+    "test:plan-validation": "bun run tests/validate-plan-validation-state.ts",
     "postinstall": "bun run wxt prepare",
     "prepare": "husky",
     "tailwind:init": "bun run tailwindcss init -p"

--- a/tests/validate-plan-validation-state.ts
+++ b/tests/validate-plan-validation-state.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import {
+  requirementsMadeStaleBy,
+  unvalidatedRequirement,
+} from "../lib/general-types";
+import type {
+  AuditValidationState,
+  CompositeValidationState,
+  PlanChange,
+  RequirementValidation,
+} from "../lib/general-types";
+
+// Default state: a requirement starts unchecked, fresh, and never validated.
+assert.deepEqual(unvalidatedRequirement(), {
+  result: "unchecked",
+  isStale: false,
+  lastValidated: null,
+});
+
+// Each call returns a fresh object, so callers never share a mutable default.
+assert.notEqual(unvalidatedRequirement(), unvalidatedRequirement());
+
+// Adding or removing a planned course marks only its own requirement stale.
+assert.deepEqual(
+  requirementsMadeStaleBy({
+    kind: "add-course",
+    auditId: "audit-123",
+    requirementTitle: "Core Curriculum",
+  }),
+  ["Core Curriculum"],
+);
+assert.deepEqual(
+  requirementsMadeStaleBy({
+    kind: "remove-course",
+    auditId: "audit-123",
+    requirementTitle: "Major Requirements",
+  }),
+  ["Major Requirements"],
+);
+
+// Moving a course between semesters changes no requirement's satisfaction, so
+// nothing goes stale (matches the ticket's transitions table).
+assert.deepEqual(
+  requirementsMadeStaleBy({ kind: "move-course", auditId: "audit-123" }),
+  [],
+);
+
+// Result and staleness are independent dimensions: "confirmed + stale" must be
+// representable and distinct from "failed + stale".
+const confirmedButStale: RequirementValidation = {
+  result: "confirmed",
+  isStale: true,
+  lastValidated: new Date("2026-01-01"),
+};
+const failedAndStale: RequirementValidation = {
+  result: "failed",
+  isStale: true,
+  lastValidated: new Date("2026-01-01"),
+};
+assert.notEqual(confirmedButStale.result, failedAndStale.result);
+assert.equal(confirmedButStale.isStale, failedAndStale.isStale);
+
+// "Validate" transition: the result updates and staleness resets to fresh.
+const afterValidate: RequirementValidation = {
+  ...confirmedButStale,
+  isStale: false,
+  lastValidated: new Date(),
+};
+assert.equal(afterValidate.isStale, false);
+assert.notEqual(afterValidate.lastValidated, null);
+
+// State model is per-audit, then per-requirement (mirrors 6.1's composite shape).
+const auditState: AuditValidationState = {
+  "Core Curriculum": unvalidatedRequirement(),
+};
+const composite: CompositeValidationState = {
+  "audit-123": auditState,
+};
+assert.equal(composite["audit-123"]["Core Curriculum"].result, "unchecked");
+
+// A plan change addresses the matching per-audit slot: apply the helper's
+// requirement IDs under change.auditId.
+const change: PlanChange = {
+  kind: "add-course",
+  auditId: "audit-123",
+  requirementTitle: "Core Curriculum",
+};
+for (const reqId of requirementsMadeStaleBy(change)) {
+  composite[change.auditId][reqId] = {
+    ...composite[change.auditId][reqId],
+    isStale: true,
+  };
+}
+assert.equal(composite["audit-123"]["Core Curriculum"].isStale, true);
+
+console.log("plan-validation-state: all assertions passed");


### PR DESCRIPTION
Implements ticket [DAP-84 — 6.4 Define validation state types for plan requirements](https://linear.app/longhorn-devs/issue/DAP-84/64-define-validation-state-types-for-plan-requirements).

## Why this matters — roadmap & vision

Sprint 6 ("Multi-audit handling") is building toward a single planner where a student pursuing e.g. **CS major + Math minor + Core Curriculum** can load all their audits at once, drop in *planned* courses, and hit **"Validate Plan"** to ask the real UT audit system *"what if I took these?"* — then see, per requirement, what's confirmed, what failed, and what's gone stale since the last check.

This PR defines the **shared data contract** the rest of that sprint compiles against:

| Ticket | Role | Relationship to this PR |
| -- | -- | -- |
| **6.1 / DAP-83** — Refactor AuditData to hold multiple audits | The composite container. `main`'s recent `CachedCompositeAudit` + storage CRUD (#162) is its persistence layer. | ✅ Done — this PR's `CompositeValidationState` slots onto it |
| **6.4 / DAP-84** — *this PR* — Validation-state types | The per-requirement `(result, isStale, lastValidated)` model + composite keying. | 🔵 In review |
| **6.5 / DAP-87** — Display validation state on cards | *Reads* these types to render status icons. | Depends on this PR |
| **6.6 / DAP-88** — "Validate Plan" button (*"the core action of the whole sprint"*) | *Writes* these types. | Depends on this PR (+ 6.5) |

Concretely, landing these types first unblocks:

- **6.6 (Validate button)** — its acceptance criteria literally say *"update each requirement's validation result to `confirmed` or `failed`, and reset staleness to `fresh`."* That is exactly `RequirementValidation` and the "Validate" transition modeled here — the button now has a defined target to write into.
- **6.5 (card display)** — its spec is a **Result × Fresh/Stale matrix** (`confirmed + stale` → green check + amber dot; `failed + stale` → red warning + amber dot). Keeping result and staleness as **separate** fields (the central design decision here) is what makes "was passing, plan changed" renderable at all; folding staleness into the result enum would make that distinction impossible.
- **Cheap staleness between validations** — `requirementsMadeStaleBy()` lets plan edits (add/remove course) flag the affected requirement stale so 6.5 can show the amber dot *without* re-running a full audit scrape.
- **Multi-audit scale** — `CompositeValidationState` is keyed by `AuditId` then requirement, mirroring 6.1's composite (`CachedCompositeAudit` / `auditData_<id>`), so validation state attaches per-audit across a multi-audit plan.

In one line: this PR is the **vocabulary** that 6.5 (display) and 6.6 (validate action) both build on, so they can proceed in parallel against a stable contract instead of each inventing its own state shape.

## What this PR does

Adds the type foundation for tracking, **per requirement per audit**, both what a validation check last found **and** whether that result is still current. Three parts: the core type model (the ticket deliverable), a test, and frontend scaffolding that will consume these concepts.

### 1. Validation-state type model (`lib/general-types.ts`) — the ticket deliverable

Each plan requirement carries **two independent dimensions**, deliberately kept as separate fields rather than one enum:

- **`ValidationResult`** = `"unchecked" | "confirmed" | "failed"` — what the last check found.
- **`RequirementValidation`** = `{ result: ValidationResult; isStale: boolean; lastValidated: Date | null }` — the full per-requirement state. `isStale` is a **separate boolean**, never folded into `result`.

Keeping the two dimensions separate preserves the distinction between *"was confirmed, but I changed the plan so it might not hold anymore"* and *"was already failing and is now also outdated."*

Supporting pieces:

- **`unvalidatedRequirement()`** — factory for the default `{ unchecked, false, null }`; returns a fresh object each call so callers never share a mutable default.
- **`AuditId` / `RequirementId`** — requirements are keyed by their **title** (they have no separate id), matching how `addPlannedCourse` already resolves them.
- **`AuditValidationState`** = `Record<RequirementId, RequirementValidation>` and **`CompositeValidationState`** = `Record<AuditId, AuditValidationState>` — per-audit, then per-requirement.
- **`PlanChange`** — discriminated union: `add-course` / `remove-course` (carry `auditId` + `requirementTitle`) and `move-course` (carries only `auditId`).
- **`requirementsMadeStaleBy(change)`** — the required helper. Conservative for v1 per the ticket's note: add/remove marks only that one requirement stale; move marks nothing.

### 2. Test (`tests/validate-plan-validation-state.ts`, `bun run test:plan-validation`)

A `node:assert` test covering every acceptance criterion: default state, fresh-object-per-call, add/remove marks one requirement while move marks none, the `confirmed + stale` vs `failed + stale` distinction, the "Validate" transition (result updates + staleness resets to fresh), and applying a `PlanChange` to a `CompositeValidationState`.

### 3. Frontend scaffolding — course-add panel (`course-add-panel.tsx` + related types)

Groundwork toward the eventual "validate a planned course against requirements" flow:

- **`PlanRequirementValidationState`** = `idle | checking | resolved` — the panel's **transient async UI state** (distinct from the persisted `RequirementValidation` model above; disambiguated by doc comments).
- **`CourseRequirementFit`** = `fulfills | no-match | check-failed` — outcome of checking one course against requirement rules, plus type guards `isValidationChecking` / `isCourseRequirementFulfilled`.
- **`CourseAddPanel`** — a search-results panel: select a course → async fit-check runs → "Add Course" enables only on `fulfills`. Uses a request-id ref to ignore out-of-order async responses.

> **Note for reviewers:** `CourseAddPanel` is **not yet wired into the app**, and its check (`try_add_course`) is a **placeholder** that always returns `no-match` ("Requirement check not yet implemented"). This is intentional scaffolding.

## Notes

- Merged latest `main` into this branch and resolved a `package.json` conflict by keeping the test scripts from both sides. `lib/general-types.ts` auto-merged cleanly alongside main's `CachedCompositeAudit`.
- CI-clean locally: `bun run compile` (0 errors), `bun run eslint` (0 errors), `bun prettier . --check` (clean), and all test scripts pass.
