### PR TITLE
Phase 6: Provider single-writer data flow, drop composite hot path, expose remove

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,14 +106,18 @@ the existing keys and stored shapes for:
 
 - audit history (`getAuditHistory`, `observeAuditHistory`, `saveAuditHistory`,
   `renameAudit`);
-- individual audit data (`getAuditData`, `watchAuditData`, `saveAuditData`,
-  `getUncachedAuditIds`); and
+- individual audit data (`getAuditData`, `watchAuditData`, `observeAuditData`,
+  `saveAuditData`, `getUncachedAuditIds`); and
 - saved audit combinations (`getCachedComposites`, `createComposite`,
   `updateCachedComposite`, `deleteCachedComposite`, `loadCompositeAudit`).
 
-`observeAuditHistory` hides the initial read plus subsequent storage watch behind
-one cleanup function. It prevents a delayed initial read from overwriting a newer
-watched update.
+`observeAuditHistory` and `observeAuditData` each hide the initial read plus
+subsequent storage watch behind one cleanup function. Both prevent a delayed
+initial read from overwriting a newer watched update. `observeAuditData` is the
+provider's single writer of the selected audit: one effect selects the id, a
+second observes its data, and no code path reads audit data alongside the
+observer. This keeps a single source of truth and avoids the blank-flash that two
+competing writers caused.
 
 `audit-mutations.ts` contains immutable, browser-free changes to cached audit
 data: add, remove, wipe, and move planned courses. `audit-calculations.ts`

--- a/features/audit/audit-provider.tsx
+++ b/features/audit/audit-provider.tsx
@@ -3,7 +3,6 @@ import {
   type AuditHistoryEntry,
   type AuditRequirement,
   type CachedAuditData,
-  type CompositeAuditData,
   getAuditDisplayName,
 } from "@/domain/audit";
 import type {
@@ -14,22 +13,19 @@ import type {
 } from "@/domain/course";
 import type { CurrentAuditProgress } from "@/domain/progress";
 import LoadingPage from "@/components/loading-page";
+import { calculateWeightedDegreeCompletion } from "./audit-calculations";
 import {
-  calculateWeightedDegreeCompletion,
-  getCompositeAuditRequirements,
-} from "./audit-calculations";
-import {
-  getAuditData,
+  observeAuditData,
   observeAuditHistory,
   renameAudit,
   saveAuditData,
-  watchAuditData,
 } from "./audit-storage";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { usePreferences } from "@/features/preferences/preferences-provider";
 import {
   addPlannedCourse as addCourse,
   moveCourseToSemester,
+  removePlannedCourse as removeCourse,
 } from "./audit-mutations";
 
 type SemesterInfo = Record<StringSemester, Course[]>;
@@ -55,6 +51,7 @@ interface AuditContextValue {
     requirementTitle: string,
     ruleTitle: string,
   ) => Promise<CourseId | null>;
+  removePlannedCourse: (courseId: CourseId) => Promise<boolean>;
 }
 
 const AuditContext = createContext<AuditContextValue | null>(null);
@@ -79,24 +76,11 @@ export function AuditContextProvider({
   );
   const currentAuditName =
     getAuditDisplayName(currentAudit) ?? "Degree Requirements";
-  const compositeAuditData = useMemo<CompositeAuditData>(
-    () =>
-      auditData && currentAuditId
-        ? {
-            audits: [
-              {
-                ...auditData,
-                name: getAuditDisplayName(currentAudit) ?? currentAuditId,
-              },
-            ],
-          }
-        : { audits: [] },
-    [auditData, currentAudit, currentAuditId],
-  );
-  const sections = useMemo(
-    () => getCompositeAuditRequirements(compositeAuditData),
-    [compositeAuditData],
-  );
+  // Single-audit hot path reads requirements directly. The composite decorations
+  // (per-audit names, duplicate-course flags) live in audit-calculations.ts
+  // (getCompositeAuditRequirements) for the future multi-audit feature; no
+  // single-audit UI reads them, so we don't compute them here.
+  const sections = auditData?.requirements ?? [];
   const courseMap = useMemo(() => auditData?.courses ?? {}, [auditData]);
   const progresses = useMemo(
     () => calculateWeightedDegreeCompletion(sections, courseMap),
@@ -123,48 +107,43 @@ export function AuditContextProvider({
     );
   }, []);
 
-  useEffect(() => {
-    if (!currentAuditId) return;
-
-    setAuditData(null);
-    return watchAuditData(currentAuditId, setAuditData);
-  }, [currentAuditId]);
-
+  // Effect A (ids only): keep currentAuditId valid against history. If the
+  // current id isn't a known audit, fall back to the first valid one. Never
+  // touches auditData.
   useEffect(() => {
     if (!history) return;
 
-    const storedHistory = history;
-    let cancelled = false;
-    setLoaded(false);
+    const isKnown = history.audits.some(
+      ({ auditId }) => auditId === currentAuditId,
+    );
+    if (isKnown) return;
 
-    async function loadAudit() {
-      try {
-        const selectedId = storedHistory.audits.some(
-          ({ auditId }) => auditId === currentAuditId,
-        )
-          ? currentAuditId
-          : storedHistory.audits.find(({ auditId }) => auditId)?.auditId;
-        if (!selectedId) return;
-
-        if (selectedId !== currentAuditId) {
-          setCurrentAuditIdState(selectedId);
-          updateLastAuditId(selectedId);
-          return;
-        }
-        const storedAudit = await getAuditData(selectedId);
-        if (!cancelled) setAuditData(storedAudit);
-      } catch (error) {
-        console.error("Failed to load audit:", error);
-      } finally {
-        if (!cancelled) setLoaded(true);
-      }
+    const fallbackId = history.audits.find(({ auditId }) => auditId)?.auditId;
+    if (fallbackId && fallbackId !== currentAuditId) {
+      setCurrentAuditIdState(fallbackId);
+      updateLastAuditId(fallbackId);
     }
-
-    void loadAudit();
-    return () => {
-      cancelled = true;
-    };
   }, [currentAuditId, history, updateLastAuditId]);
+
+  // Effect B (sole auditData writer): observe the selected audit. The watch wins
+  // over a late initial read, so switching audits never flashes null — the
+  // `loaded` gate shows LoadingPage until the observed data arrives.
+  useEffect(() => {
+    if (!currentAuditId) return;
+
+    setLoaded(false);
+    return observeAuditData(
+      currentAuditId,
+      (audit) => {
+        setAuditData(audit);
+        setLoaded(true);
+      },
+      (error) => {
+        console.error("Failed to load audit:", error);
+        setLoaded(true);
+      },
+    );
+  }, [currentAuditId]);
 
   const value = useMemo<AuditContextValue>(() => {
     // currentAuditId and history are guaranteed non-null past the loading
@@ -214,6 +193,13 @@ export function AuditContextProvider({
         if (!result) return null;
         await saveAuditData(currentAuditId, result.audit);
         return result.courseId;
+      },
+      removePlannedCourse: async (courseId) => {
+        if (!auditData || !currentAuditId) return false;
+        const updated = removeCourse(auditData, courseId);
+        if (!updated) return false;
+        await saveAuditData(currentAuditId, updated);
+        return true;
       },
     };
   }, [

--- a/features/audit/audit-storage.ts
+++ b/features/audit/audit-storage.ts
@@ -109,6 +109,38 @@ export function watchAuditData(
   );
 }
 
+/**
+ * Observe a single audit's data: an initial read plus a subsequent storage
+ * watch behind one cleanup function. A delayed initial read never overwrites a
+ * newer watched update (mirrors {@link observeAuditHistory}). This is the single
+ * writer of audit data in the provider — callers should not also read directly.
+ */
+export function observeAuditData(
+  auditId: string,
+  listener: (audit: CachedAuditData | null) => void,
+  onError?: (error: unknown) => void,
+): () => void {
+  let active = true;
+  let receivedUpdate = false;
+  const unwatch = watchAuditData(auditId, (audit) => {
+    receivedUpdate = true;
+    if (active) listener(audit);
+  });
+
+  void getAuditData(auditId)
+    .then((audit) => {
+      if (active && !receivedUpdate) listener(audit);
+    })
+    .catch((error: unknown) => {
+      if (active && !receivedUpdate) onError?.(error);
+    });
+
+  return () => {
+    active = false;
+    unwatch();
+  };
+}
+
 export async function getUncachedAuditIds(
   auditIds: string[],
 ): Promise<string[]> {


### PR DESCRIPTION

## What changed

### Drop the composite hot path (Decision 2)
The provider wrapped every single audit in a fake composite (`compositeAuditData` memo) just to call `getCompositeAuditRequirements`, which recomputed per-audit names and duplicate-course flags that **no single-audit UI reads**. Replaced with a direct `sections = auditData?.requirements ?? []`. The composite calculations stay in `audit-calculations.ts` (still exported, still used by the validation scripts) for the future multi-audit feature — a pointer comment marks why.

### Single-writer data flow (fixes the blank flash)
Two effects previously both wrote `auditData` and raced, with a `setAuditData(null)` that flashed empty content on every audit switch. Split into single-responsibility effects:
- **Effect A (ids only):** keeps `currentAuditId` valid against history, falling back to the first valid audit. Never touches `auditData`.
- **Effect B (sole `auditData` writer):** new `observeAuditData()` in `audit-storage.ts`, mirroring `observeAuditHistory` (initial read + watch, watch wins over a late initial read). `setLoaded(false)` on switch so the `loaded` gate shows `LoadingPage` instead of a null flash.

### Expose `removePlannedCourse` (Decision 4)
Added `removePlannedCourse(courseId): Promise<boolean>` to the context, implemented like `moveCourseToNewSemester` over the existing `audit-mutations.removePlannedCourse` helper. Only `Planned` courses are removable (completed courses can't be). `wipePlannedCourses` stays unexposed (no designed affordance). This is the "unplan" half that Phase 10 will wire to a planner remove button.

