### PR TITLE
Fix catalog search matching and remove duplicate query/dedupe logic

### DIFF
--- a/features/catalog/catalog-course-mappers.ts
+++ b/features/catalog/catalog-course-mappers.ts
@@ -37,6 +37,23 @@ export function catalogCourseToPlannedCourse(
   };
 }
 
+// Matches a catalog course against an already-normalized (trimmed, lowercased)
+// query across code, title, short name, and instructor names. Shared by the
+// in-memory filter and the Dexie-backed search so both stay in sync.
+export function matchesCatalogQuery(
+  course: CatalogCourse,
+  normalizedQuery: string,
+): boolean {
+  if (!normalizedQuery) return true;
+
+  return [
+    `${course.department} ${course.number}`,
+    course.fullName,
+    course.courseName,
+    course.instructors.map(({ fullName }) => fullName).join(" "),
+  ].some((value) => value.toLowerCase().includes(normalizedQuery));
+}
+
 export function filterCatalogCourses(
   courses: CatalogCourse[],
   query: string,
@@ -45,11 +62,6 @@ export function filterCatalogCourses(
   if (!normalizedQuery) return courses;
 
   return courses.filter((course) =>
-    [
-      `${course.department} ${course.number}`,
-      course.fullName,
-      course.courseName,
-      course.instructors.map(({ fullName }) => fullName).join(" "),
-    ].some((value) => value.toLowerCase().includes(normalizedQuery)),
+    matchesCatalogQuery(course, normalizedQuery),
   );
 }

--- a/features/catalog/catalog-db.ts
+++ b/features/catalog/catalog-db.ts
@@ -1,6 +1,10 @@
 import Dexie from "dexie";
 import type { CatalogCourse } from "@/domain/catalog";
 import type { CoreArea } from "@/domain/course";
+import {
+  dedupeCatalogCoursesByCode,
+  matchesCatalogQuery,
+} from "./catalog-course-mappers";
 import { DEPARTMENT_MAP } from "./department-map";
 
 export class UTDatabase extends Dexie {
@@ -34,19 +38,8 @@ export async function searchCores(
   }
 
   const courses = await findCoursesByCore(core);
-  const seenCourseCodes = new Set<string>();
 
-  return courses
-    .filter((course) => {
-      const courseCode = `${course.department} ${course.number}`;
-      if (seenCourseCodes.has(courseCode)) {
-        return false;
-      }
-
-      seenCourseCodes.add(courseCode);
-      return true;
-    })
-    .slice(0, limit);
+  return dedupeCatalogCoursesByCode(courses).slice(0, limit);
 }
 
 function getDepartmentCodesByName(departmentName: string): string[] {
@@ -71,11 +64,8 @@ export function searchCatalogCourses(filters: {
   return db.courses
     .toCollection()
     .filter((course) => {
-      // Match the search text against the catalog title fields.
-      const matchesQuery =
-        normalizedQuery.length === 0 ||
-        course.fullName.toLowerCase().includes(normalizedQuery) ||
-        course.courseName.toLowerCase().includes(normalizedQuery);
+      // Match the search text against code, title, short name, and instructors.
+      const matchesQuery = matchesCatalogQuery(course, normalizedQuery);
 
       // Match the selected department name against the stored department codes.
       const matchesDepartment =

--- a/features/catalog/department-map.ts
+++ b/features/catalog/department-map.ts
@@ -227,7 +227,7 @@ export const DEPARTMENT_MAP: Record<string, string> = {
   VIA: "Viola",
   VIO: "Violin",
   VOI: "Voice",
-  WGS: "Women&#x27;s and Gender Studies",
+  WGS: "Women's and Gender Studies",
   WRT: "Writing",
   YID: "Yiddish",
   YOR: "Yoruba",

--- a/features/course-search/course-search-panel.tsx
+++ b/features/course-search/course-search-panel.tsx
@@ -12,7 +12,6 @@ import {
   CaretLeftIcon,
   ChalkboardTeacherIcon,
   CircleNotchIcon,
-  GraduationCapIcon,
 } from "@phosphor-icons/react";
 import { useState } from "react";
 import CourseCard from "./course-card";
@@ -156,22 +155,6 @@ function CourseSearchContent({
         />
 
         <div className="flex items-center gap-3 my-4" />
-
-        <div className="mb-4">
-          <SelectDropdown
-            icon={<GraduationCapIcon size={28} />}
-            placeholder="Requirement"
-            options={DEPARTMENTS}
-            value={formData.department}
-            onChange={(value) =>
-              setFormData((previous) => ({
-                ...previous,
-                department: value,
-              }))
-            }
-            disabled={isSearching}
-          />
-        </div>
 
         <div className="mb-4">
           <SelectDropdown


### PR DESCRIPTION
## Summary

Fixes the bug/correctness cluster from the Phase 9 plan (no file splitting, hook, or CourseCard merge — those structural pieces were deliberately left out).

## Changes

1. **Catalog DB search was silently broken for code/instructor queries.** `searchCatalogCourses` only matched `fullName`/`courseName`, so searching the catalog by course code or instructor name returned nothing. Extracted a shared `matchesCatalogQuery` (code + title + short name + instructors) and used it in both `filterCatalogCourses` and `searchCatalogCourses` so the two search paths stay in sync.

2. **Removed duplicate dedupe logic.** `searchCores` reimplemented `dedupeCatalogCoursesByCode` inline with a `Set` loop — replaced with the existing helper.

3. **Deleted the duplicate "Requirement" dropdown** in the course-search panel. It bound the same `formData.department` as the Department dropdown and rendered the same options, so it did nothing distinct. Also removed the now-unused `GraduationCapIcon` import.

4. **Decoded a leaked HTML entity** in the department map: `Women&#x27;s` → `Women's` (verified it was the only one).

## Notes

- `npx tsc --noEmit` passes clean.
- Behavior change worth a look during review: catalog search now also matches **instructor names**, which is the intended behavior but slightly widens results compared to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)