### PR TITLE
fix: make dark mode borders white

### DIFF
--- a/entrypoints/popup-app/style.css
+++ b/entrypoints/popup-app/style.css
@@ -85,6 +85,7 @@ html.dark {
   --color-dap-orange: #1a2024;
   --color-background: #1a1a1a;
   --color-text: #f5f5f5;
+  --color-dap-border: #ffffff;
 }
 
 /* Create rounded popup effect */

--- a/entrypoints/styles/content.css
+++ b/entrypoints/styles/content.css
@@ -93,7 +93,7 @@ html.dark,
   --color-background: #272727;
   --color-text: #ffffff;
   --color-muted: #9ca3af;
-  --color-dap-border: #4f4f4f;
+  --color-dap-border: #ffffff;
   --color-hover-bg: #333333;
 }
 

--- a/features/popup/popup-app.tsx
+++ b/features/popup/popup-app.tsx
@@ -123,8 +123,8 @@ export default function App() {
   const needsLogin = loggedIn === false;
 
   return (
-    <div className="w-[438px] h-full min-h-[300px] max-h-[600px] bg-background font-sans overflow-hidden flex flex-col border border-gray-100">
-      <header className="flex justify-between items-center px-5 py-4 border-b border-gray-200 flex-shrink-0">
+    <div className="w-[438px] h-full min-h-[300px] max-h-[600px] bg-background font-sans overflow-hidden flex flex-col border border-dap-border">
+      <header className="flex justify-between items-center px-5 py-4 border-b border-dap-border flex-shrink-0">
         <div className="flex items-center space-x-2">
           <img
             src={logo}


### PR DESCRIPTION
﻿## Summary
- Set `--color-dap-border` to white in dark mode (content + popup styles)
- Point the popup shell/header borders at `border-dap-border` instead of hardcoded gray so dark mode stays visible

Closes #188

## Test plan
- [ ] Toggle dark mode in the extension popup and confirm the outer and header borders render white
- [ ] Confirm light mode borders still use the cream `dap-border` token
