### PR TITLE
fix(dashboard): move theme toggle to sidebar footer

### DIFF
--- a/features/dashboard/navbar.tsx
+++ b/features/dashboard/navbar.tsx
@@ -6,10 +6,8 @@ import { getAuditDisplayName } from "@/domain/audit";
 import { cn } from "@/lib/utils";
 import {
   ExportIcon,
-  MoonIcon,
   PencilIcon,
   Sidebar as SidebarIcon,
-  SunIcon,
 } from "@phosphor-icons/react";
 
 const MAJOR_TAG_STYLES = [
@@ -26,14 +24,8 @@ const MINOR_TAG_STYLES = [
 ];
 
 const Navbar = () => {
-  const {
-    toggleSidebar,
-    toggleViewMode,
-    viewMode,
-    sidebarIsOpen,
-    toggleDarkMode,
-    isDarkMode,
-  } = usePreferences();
+  const { toggleSidebar, toggleViewMode, viewMode, sidebarIsOpen } =
+    usePreferences();
   const { currentAudit } = useAuditContext();
 
   const title = getAuditDisplayName(currentAudit) ?? "Degree Audit Plus";
@@ -135,12 +127,6 @@ const Navbar = () => {
         <IconButton
           icon={<ExportIcon className="w-5 h-5" />}
           label="Share"
-          className="h-10 rounded-[5px] px-[18px] bg-dap-orange gap-1.5 text-sm font-bold"
-        />
-        <IconButton
-          icon={isDarkMode ? <MoonIcon size={24} /> : <SunIcon size={24} />}
-          label={isDarkMode ? "Light Mode" : "Dark Mode"}
-          onClick={toggleDarkMode}
           className="h-10 rounded-[5px] px-[18px] bg-dap-orange gap-1.5 text-sm font-bold"
         />
       </HStack>

--- a/features/dashboard/sidebar.tsx
+++ b/features/dashboard/sidebar.tsx
@@ -2,21 +2,23 @@ import DegreeAuditCard from "./audit-card";
 import { usePreferences } from "@/features/preferences/preferences-provider";
 import logo from "@/public/logo.png";
 import {
-  ArrowUpRight,
-  DiscordLogo,
-  Gear,
-  GithubLogo,
-  InstagramLogo,
-  LinkedinLogo,
-  Moon,
-  Plus,
-  Sidebar as SidebarIcon,
+  ArrowUpRightIcon,
+  DiscordLogoIcon,
+  GearIcon,
+  GithubLogoIcon,
+  InstagramLogoIcon,
+  LinkedinLogoIcon,
+  MoonIcon,
+  PlusIcon,
+  SidebarIcon,
+  SunIcon,
 } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useAuditContext } from "@/features/audit/audit-provider";
 
 const Sidebar = () => {
-  const { sidebarIsOpen, toggleSidebar } = usePreferences();
+  const { sidebarIsOpen, toggleSidebar, toggleDarkMode, isDarkMode } =
+    usePreferences();
   const { currentAuditId, setCurrentAuditId, history, renameAuditTitle } =
     useAuditContext();
   return (
@@ -55,7 +57,7 @@ const Sidebar = () => {
             MY AUDITS
           </span>
           <button className="p-1 hover:bg-black/5 rounded">
-            <Plus size={24} className="text-text" />
+            <PlusIcon size={24} className="text-text" />
           </button>
         </div>
 
@@ -102,25 +104,25 @@ const Sidebar = () => {
             href="#"
             className="text-dap-orange text-[15px] font-medium hover:underline flex items-center gap-1"
           >
-            UT Core Requirements <ArrowUpRight size={14} />
+            UT Core Requirements <ArrowUpRightIcon size={14} />
           </a>
           <a
             href="#"
             className="text-dap-orange text-[15px] font-medium hover:underline flex items-center gap-1"
           >
-            UT Degree Plans <ArrowUpRight size={14} />
+            UT Degree Plans <ArrowUpRightIcon size={14} />
           </a>
           <a
             href="#"
             className="text-dap-orange text-[15px] font-medium hover:underline flex items-center gap-1"
           >
-            Registration Info Sheet (RIS) <ArrowUpRight size={14} />
+            Registration Info Sheet (RIS) <ArrowUpRightIcon size={14} />
           </a>
           <a
             href="#"
             className="text-dap-orange text-[15px] font-medium hover:underline flex items-center gap-1"
           >
-            Register for Courses <ArrowUpRight size={14} />
+            Register for Courses <ArrowUpRightIcon size={14} />
           </a>
         </div>
 
@@ -132,7 +134,7 @@ const Sidebar = () => {
           href="#"
           className="text-dap-orange font-semibold hover:underline flex items-center gap-1"
         >
-          Send us Feedback! <ArrowUpRight size={14} />
+          Send us Feedback! <ArrowUpRightIcon size={14} />
         </a>
       </div>
 
@@ -152,22 +154,28 @@ const Sidebar = () => {
         </div>
         <div className="flex items-center w-full gap-4 text-text">
           <a href="#" aria-label="Discord">
-            <DiscordLogo size={24} />
+            <DiscordLogoIcon size={24} />
           </a>
           <a href="#" aria-label="Instagram">
-            <InstagramLogo size={24} />
+            <InstagramLogoIcon size={24} />
           </a>
           <a href="#" aria-label="LinkedIn">
-            <LinkedinLogo size={24} />
+            <LinkedinLogoIcon size={24} />
           </a>
           <a href="#" aria-label="GitHub">
-            <GithubLogo size={24} />
+            <GithubLogoIcon size={24} />
           </a>
-          <a href="#" aria-label="Dark Mode" className="ml-auto">
-            <Moon size={24} />
-          </a>
+          <button
+            className="ml-auto"
+            onClick={toggleDarkMode}
+            aria-label={
+              isDarkMode ? "Switch to light mode" : "Switch to dark mode"
+            }
+          >
+            {isDarkMode ? <SunIcon size={24} /> : <MoonIcon size={24} />}
+          </button>
           <a href="#" aria-label="Settings">
-            <Gear size={24} />
+            <GearIcon size={24} />
           </a>
         </div>
       </div>


### PR DESCRIPTION
DAP-109 (resolves #205)

- Removed theme toggle button in navbar
- Wired theme toggle to work on button in sidebar footer
- Replaced deprecated Phosphor sidebar icon imports with their *Icon equivalents (TODO: do this for all other files where we use these icons)

<img width="1512" height="823" alt="Screenshot 2026-07-20 at 7 06 51 PM" src="https://github.com/user-attachments/assets/959d22fd-079a-4c90-af28-c7387a85c238" />
<img width="1512" height="822" alt="Screenshot 2026-07-20 at 7 07 06 PM" src="https://github.com/user-attachments/assets/6aaee354-b9c5-4508-95b5-0fb1d95a0860" />
