### PR TITLE
   Remove redundant validation message for division toggles in course search

### DIFF
--- a/features/course-search/course-search-panel.tsx
+++ b/features/course-search/course-search-panel.tsx
@@ -86,7 +86,7 @@ function CourseSearchContent({
     lowerDivision: true,
     upperDivision: true,
   });
-  const [validationError, setValidationError] = useState("");
+
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const isSearching = isLoading || isSubmitting;
@@ -107,13 +107,6 @@ function CourseSearchContent({
 
   const handleSearch = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!formData.lowerDivision && !formData.upperDivision) {
-      setValidationError(
-        "Please select at least one course division (Lower or Upper)",
-      );
-      return;
-    }
-    setValidationError("");
     if (!onSearchSubmit) return;
 
     try {
@@ -186,25 +179,6 @@ function CourseSearchContent({
             onToggle={() => handleToggle("upperDivision")}
           />
         </div>
-
-        {validationError && (
-          <div className="flex items-center gap-3 px-4 py-3 bg-red-50 border border-red-200 rounded-xl mb-4">
-            <svg
-              className="w-5 h-5 text-red-600 flex-shrink-0"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
-            <p className="text-sm text-red-700">{validationError}</p>
-          </div>
-        )}
 
         <Button
           type="submit"


### PR DESCRIPTION
Fix is for issue #202 

Removes the validation error message for the lower/upper division toggle check in `course-search-panel.tsx`, since the Search button is already disabled in that state — the message was unreachable dead code. Confirmed with @Sidd03192 that disabling is the preferred pattern.

Deleted useState for validationError as it was no longer needed in the code.