### PR TITLE
fix(session): gate cookie-watcher probes by session value and interval

### DIFF
--- a/features/popup/popup-app.tsx
+++ b/features/popup/popup-app.tsx
@@ -102,7 +102,7 @@ export default function App() {
     });
   };
 
-  // The background owns the auth checks: 
+  // The background owns the auth checks:
   const handleRerunAudit = async () => {
     setRunningAudit(true);
     try {

--- a/features/session/session.ts
+++ b/features/session/session.ts
@@ -77,19 +77,47 @@ export function isLoginPage(document: Document): boolean {
   );
 }
 
+
+// Probe only when the session id actually changed, and never more often than this
+const COOKIE_PROBE_MIN_INTERVAL_MS = 60_000;
+
+// Decides whether a session-cookie set event warrants a network probe.
+export function createCookieProbeGate(
+  minIntervalMs = COOKIE_PROBE_MIN_INTERVAL_MS,
+) {
+  let lastValue: string | undefined;
+  let lastProbeAt = -Infinity;
+  return {
+    shouldProbe(value: string, now: number): boolean {
+      if (value === lastValue) return false;
+      lastValue = value;
+      if (now - lastProbeAt < minIntervalMs) return false;
+      lastProbeAt = now;
+      return true;
+    },
+    reset(): void {
+      lastValue = undefined;
+    },
+  };
+}
+
 // Event-driven cache updates from the background service worker: react the
 // moment the session cookie is removed or (re)created, instead of waiting for
 // the next popup open. Requires the "cookies" permission.
 export function registerSessionCookieWatcher(): void {
   if (!browser.cookies?.onChanged) return;
 
+  const gate = createCookieProbeGate();
   browser.cookies.onChanged.addListener(({ cookie, removed, cause }) => {
     if (cookie.name !== SESSION_COOKIE) return;
     if (removed) {
       // "overwrite" removals are immediately followed by a set event for the
       // replacement cookie — not a logout.
-      if (cause !== "overwrite") void saveLoginState(false);
-    } else {
+      if (cause !== "overwrite") {
+        gate.reset();
+        void saveLoginState(false);
+      }
+    } else if (gate.shouldProbe(cookie.value, Date.now())) {
       void refreshLoginState();
     }
   });

--- a/features/session/session.ts
+++ b/features/session/session.ts
@@ -77,7 +77,6 @@ export function isLoginPage(document: Document): boolean {
   );
 }
 
-
 // Probe only when the session id actually changed, and never more often than this
 const COOKIE_PROBE_MIN_INTERVAL_MS = 60_000;
 

--- a/tests/session/cookie-probe-gate.test.ts
+++ b/tests/session/cookie-probe-gate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { createCookieProbeGate } from "../../features/session/session";
+
+// UT re-sets the session cookie on every response, including the login probe's
+// own; the gate keeps the cookie watcher from probing in a loop.
+describe("cookie probe gate", () => {
+  test("probes once for a new session id, then ignores identical re-sets", () => {
+    const gate = createCookieProbeGate(60_000);
+    expect(gate.shouldProbe("abc", 0)).toBe(true);
+    expect(gate.shouldProbe("abc", 100)).toBe(false);
+    expect(gate.shouldProbe("abc", 200)).toBe(false);
+  });
+
+  test("throttles probes for changing ids to one per interval", () => {
+    const gate = createCookieProbeGate(60_000);
+    expect(gate.shouldProbe("a", 0)).toBe(true);
+    expect(gate.shouldProbe("b", 1_000)).toBe(false);
+    expect(gate.shouldProbe("c", 59_999)).toBe(false);
+    expect(gate.shouldProbe("d", 60_000)).toBe(true);
+    expect(gate.shouldProbe("e", 60_001)).toBe(false);
+  });
+
+  test("a rotated id inside the interval is not re-probed later just for repeating", () => {
+    const gate = createCookieProbeGate(60_000);
+    expect(gate.shouldProbe("a", 0)).toBe(true);
+    expect(gate.shouldProbe("b", 1_000)).toBe(false);
+    // Same value again after the interval — nothing new to learn.
+    expect(gate.shouldProbe("b", 70_000)).toBe(false);
+  });
+
+  test("reset() treats the next set as a new session even with the same id", () => {
+    const gate = createCookieProbeGate(60_000);
+    expect(gate.shouldProbe("abc", 0)).toBe(true);
+    gate.reset();
+    expect(gate.shouldProbe("abc", 60_000)).toBe(true);
+  });
+
+  test("reset() does not bypass the interval throttle", () => {
+    const gate = createCookieProbeGate(60_000);
+    expect(gate.shouldProbe("abc", 0)).toBe(true);
+    gate.reset();
+    expect(gate.shouldProbe("abc", 1_000)).toBe(false);
+  });
+});


### PR DESCRIPTION
Bug:
- `registerSessionCookieWatcher()` re-fetched `history/` every time the UT session cookie was set
- UT re-sets that cookie on every response, and Chrome send an `onChanged` even for the identical value, so the probe triggered itself in a loop (~10 req/s in the background whenever logged in)

Fix:
- the watcher now only probes when the session id actually changes, and at most once per minute.
- a real cookie removal resets it so re-login is still detected
- added some unit tests for this as well