### PR TITLE
fix(tests): stub every session/messages export in the content-controller mocks

### DIFF
--- a/tests/audit-scraping/content-controller.test.ts
+++ b/tests/audit-scraping/content-controller.test.ts
@@ -37,10 +37,14 @@ mock.module("../../features/audit-scraping/audit-runner", () => ({
     ranAudits.push(custom);
   },
 }));
+
 mock.module("../../features/session/session", () => ({
   recordLoginStateFromPage: () => {
     recordedLoginPages++;
   },
+  getCachedLoginState: async () => true,
+  openLoginTab: async () => {},
+  registerSessionCookieWatcher: () => {},
 }));
 mock.module("../../lib/browser/messages", () => ({
   sendMessageResponse: (
@@ -48,6 +52,8 @@ mock.module("../../lib/browser/messages", () => ({
     sendResponse: (response: unknown) => void,
     response: unknown,
   ) => sendResponse(response),
+  sendRuntimeMessage: async () => undefined,
+  sendTabMessage: async () => undefined,
 }));
 
 (


### PR DESCRIPTION
- bug: content-controller.test.ts mocks the session and messages modules with only the exports it uses, but Bun applies mock.module to the whole test run, so when background-controller.test.ts loads after it, its imports can't be found and CI fails
- fix: the mocks now stub every export the other test's code imports, so load order no longer matters.