### PR TITLE
fix(dashboard): close audit menu on outside click

### DIFF
--- a/features/dashboard/audit-card.tsx
+++ b/features/dashboard/audit-card.tsx
@@ -27,6 +27,20 @@ const DegreeAuditCard: React.FC<DegreeAuditCardProps> = ({
   const [menuOpen, setMenuOpen] = React.useState(false);
   const [isEditing, setIsEditing] = React.useState(false);
   const [draftTitle, setDraftTitle] = React.useState(title ?? "");
+  const cardRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!menuOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (cardRef.current && !cardRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [menuOpen]);
 
   React.useEffect(() => {
     if (!isSelected) {
@@ -54,6 +68,7 @@ const DegreeAuditCard: React.FC<DegreeAuditCardProps> = ({
 
   return (
     <div
+      ref={cardRef}
       className={`relative rounded-[8px] px-4 py-[12px] w-full transition-all duration-200 cursor-pointer ${
         isSelected
           ? "bg-dap-orange border border-dap-orange"


### PR DESCRIPTION
closes #243 

- changed the functionality of closing the audit actions menu so that it closes whenever you click anywhere outside of the box

https://github.com/user-attachments/assets/899d685c-deb1-40cd-9cc2-16f9708a65b0




